### PR TITLE
Index sorting

### DIFF
--- a/pydeseq2/DeseqDataSet.py
+++ b/pydeseq2/DeseqDataSet.py
@@ -174,15 +174,19 @@ class DeseqDataSet:
         # Test counts before going further
         test_valid_counts(counts)
         self.counts = counts
-        self.counts.sort_index(inplace=True)
 
         # Import clinical data and convert design_column to string
-        self.clinical = clinical
-        self.clinical.sort_index(inplace=True)
-        if not self.counts.index.identical(self.clinical.index):
-            raise ValueError(
-                "The count matrix and clinical data should have the same index."
+        try:
+            self.clinical = clinical.loc[self.counts.index]
+        except KeyError as e:
+            print(
+                "The count matrix and clinical data "
+                "should contain the same sample indexes."
             )
+            raise e
+        assert len(self.clinical) == len(
+            clinical
+        ), "The count matrix and clinical data should contain the same sample indexes."
         self.design_factor = design_factor
         if self.clinical[self.design_factor].isna().any():
             raise ValueError("NaNs are not allowed in the design factor.")

--- a/pydeseq2/DeseqDataSet.py
+++ b/pydeseq2/DeseqDataSet.py
@@ -175,18 +175,14 @@ class DeseqDataSet:
         test_valid_counts(counts)
         self.counts = counts
 
-        # Import clinical data and convert design_column to string
-        try:
-            self.clinical = clinical.loc[self.counts.index]
-        except KeyError as e:
-            print(
+        if set(self.counts.index) != set(clinical.index):
+            raise KeyError(
                 "The count matrix and clinical data "
                 "should contain the same sample indexes."
             )
-            raise e
-        assert len(self.clinical) == len(
-            clinical
-        ), "The count matrix and clinical data should contain the same sample indexes."
+
+        # Import clinical data and convert design_column to string
+        self.clinical = clinical.loc[self.counts.index]
         self.design_factor = design_factor
         if self.clinical[self.design_factor].isna().any():
             raise ValueError("NaNs are not allowed in the design factor.")

--- a/pydeseq2/DeseqDataSet.py
+++ b/pydeseq2/DeseqDataSet.py
@@ -174,9 +174,11 @@ class DeseqDataSet:
         # Test counts before going further
         test_valid_counts(counts)
         self.counts = counts
+        self.counts.sort_index(inplace=True)
 
         # Import clinical data and convert design_column to string
         self.clinical = clinical
+        self.clinical.sort_index(inplace=True)
         if not self.counts.index.identical(self.clinical.index):
             raise ValueError(
                 "The count matrix and clinical data should have the same index."

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -141,7 +141,7 @@ def test_indexes():
     )
     clinical_df = pd.DataFrame({"condition": [0, 1]}, index=["sample01", "sample02"])
 
-    with pytest.raises((KeyError, AssertionError)):
+    with pytest.raises(KeyError):
         DeseqDataSet(
             counts_df,
             clinical_df,

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -141,7 +141,7 @@ def test_indexes():
     )
     clinical_df = pd.DataFrame({"condition": [0, 1]}, index=["sample01", "sample02"])
 
-    with pytest.raises(ValueError):
+    with pytest.raises((KeyError, AssertionError)):
         DeseqDataSet(
             counts_df,
             clinical_df,


### PR DESCRIPTION
This PR fixes an issue that appears when the count matrix and the clinical data provided to a `DeseqDataSet` have identical sets of samples, but in a different order, by sorting the indices at initialization.