### PR TITLE
Add example notebooks for multi-factor analysis

### DIFF
--- a/notebooks/PyDESeq2_minimal_example.ipynb
+++ b/notebooks/PyDESeq2_minimal_example.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "CANCER = \"synthetic\"  # or 'TCGA-BRCA', 'TCGA-COAD', etc."
+    "DATASET = \"synthetic\"  # or 'TCGA-BRCA', 'TCGA-COAD', etc."
    ]
   },
   {
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "OUTPUT_PATH = f\"../output_files/{CANCER}\"\n",
+    "OUTPUT_PATH = f\"../output_files/{DATASET}\"\n",
     "os.makedirs(OUTPUT_PATH, exist_ok=True)  # Create path if it doesn't exist"
    ]
   },
@@ -91,7 +91,7 @@
    "source": [
     "counts_df = load_example_data(\n",
     "    modality=\"raw_counts\",\n",
-    "    cancer_type=CANCER,\n",
+    "    dataset=DATASET,\n",
     "    debug=False,\n",
     ")"
    ]
@@ -105,7 +105,7 @@
    "source": [
     "clinical_df = load_example_data(\n",
     "    modality=\"clinical\",\n",
-    "    cancer_type=CANCER,\n",
+    "    dataset=DATASET,\n",
     "    debug=False,\n",
     ")"
    ]
@@ -137,7 +137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if CANCER != \"synthetic\":\n",
+    "if DATASET != \"synthetic\":\n",
     "    samples_to_keep = ~clinical_df.high_grade.isna()\n",
     "    samples_to_keep.sum()\n",
     "    counts_df = counts_df.loc[samples_to_keep]\n",
@@ -198,7 +198,7 @@
     "dds = DeseqDataSet(\n",
     "    counts_df,\n",
     "    clinical_df,\n",
-    "    design_factors=\"condition\" if CANCER == \"synthetic\" else \"high_grade\",\n",
+    "    design_factors=\"condition\" if DATASET == \"synthetic\" else \"high_grade\",\n",
     "    refit_cooks=True,\n",
     "    n_cpus=8,\n",
     ")"

--- a/notebooks/PyDESeq2_step_by_step_pipeline.ipynb
+++ b/notebooks/PyDESeq2_step_by_step_pipeline.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "CANCER = \"synthetic\"  # or 'TCGA-BRCA', 'TCGA-COAD', etc."
+    "DATASET = \"synthetic\"  # or 'TCGA-BRCA', 'TCGA-COAD', etc."
    ]
   },
   {
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "OUTPUT_PATH = f\"../output_files/{CANCER}\"\n",
+    "OUTPUT_PATH = f\"../output_files/{DATASET}\"\n",
     "os.makedirs(OUTPUT_PATH, exist_ok=True)  # Create path if it doesn't exist"
    ]
   },
@@ -89,7 +89,7 @@
    "source": [
     "counts_df = load_example_data(\n",
     "    modality=\"raw_counts\",\n",
-    "    cancer_type=CANCER,\n",
+    "    dataset=DATASET,\n",
     "    debug=False,\n",
     ")"
    ]
@@ -103,7 +103,7 @@
    "source": [
     "clinical_df = load_example_data(\n",
     "    modality=\"clinical\",\n",
-    "    cancer_type=CANCER,\n",
+    "    dataset=DATASET,\n",
     "    debug=False,\n",
     ")"
    ]
@@ -135,7 +135,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if CANCER != \"synthetic\":\n",
+    "if DATASET != \"synthetic\":\n",
     "    samples_to_keep = ~clinical_df.high_grade.isna()\n",
     "    samples_to_keep.sum()\n",
     "    counts_df = counts_df.loc[samples_to_keep]\n",
@@ -196,7 +196,7 @@
     "dds = DeseqDataSet(\n",
     "    counts_df,\n",
     "    clinical_df,\n",
-    "    design_factors=\"condition\" if CANCER == \"synthetic\" else \"high_grade\",\n",
+    "    design_factors=\"condition\" if DATASET == \"synthetic\" else \"high_grade\",\n",
     "    refit_cooks=True,\n",
     "    n_cpus=8,\n",
     ")"

--- a/notebooks/index.ipynb
+++ b/notebooks/index.ipynb
@@ -5,11 +5,27 @@
    "id": "06f01643",
    "metadata": {},
    "source": [
-    "This notebook is a index linking to PyDESeq2 examples:\n",
+    "This notebook is an index linking to PyDESeq2 example notebooks.\n",
     "\n",
-    "* [Minimal PyDESeq2 example](./PyDESeq2_minimal_example.ipynb)\n",
-    "* [Detailed PyDESeq2 pipeline](./PyDESeq2_step_by_step_pipeline.ipynb)"
+    "* Single-factor analysis examples:\n",
+    "\n",
+    "    * [Minimal PyDESeq2 example](./PyDESeq2_minimal_example.ipynb)\n",
+    "    * [Detailed PyDESeq2 pipeline](./PyDESeq2_step_by_step_pipeline.ipynb)\n",
+    "\n",
+    "\n",
+    "* Paired multi-factor analysis examples:\n",
+    "\n",
+    "    * [Minimal multi-factor example](./PyDESeq2_minimal_multifactor_example.ipynb)\n",
+    "    * [Detailed multi-factor pipeline](./PyDESeq2_multifactor_step_by_step_pipeline.ipynb)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41c5a0d6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -38,7 +38,7 @@ def load_example_data(
         If "synthetic" or "multifactor_synthetic", will return the synthetic data that is
         used for CI unit tests. Otherwise, must be a valid TCGA dataset.
         Accepted values: ["synthetic", "multifactor_synthetic", "TCGA-BRCA", "TCGA-COAD",
-        "TCGA-LUAD", "TCGA-LUSC", "TCGA-PAAD", "TCGA-PRAD", "TCGA-READ", "TCGA-SKCM"]
+        "TCGA-LUAD", "TCGA-LUSC", "TCGA-PAAD", "TCGA-PRAD", "TCGA-READ", "TCGA-SKCM"].
         (default: "synthetic").
 
     debug : bool

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -19,7 +19,7 @@ from pydeseq2.grid_search import grid_fit_shrink_beta
 
 def load_example_data(
     modality="raw_counts",
-    cancer_type="synthetic",
+    dataset="synthetic",
     debug=False,
     debug_seed=42,
 ):
@@ -33,10 +33,13 @@ def load_example_data(
     modality : str
         Data modality. "raw_counts" or "clinical".
 
-    cancer_type : str
-        The cancer type for which to return gene expression data.
-        If "synthetic", will return the synthetic data that is used for CI unit tests.
-        Otherwise, must be a valid TCGA dataset. (default: "synthetic").
+    dataset : str
+        The dataset from which to return gene expression data.
+        If "synthetic" or "multifactor_synthetic", will return the synthetic data that is
+        used for CI unit tests. Otherwise, must be a valid TCGA dataset.
+        Accepted values: ["synthetic", "multifactor_synthetic", "TCGA-BRCA", "TCGA-COAD",
+        "TCGA-LUAD", "TCGA-LUSC", "TCGA-PAAD", "TCGA-PRAD", "TCGA-READ", "TCGA-SKCM"]
+        (default: "synthetic").
 
     debug : bool
         If true, subsample 10 samples and 100 genes at random.
@@ -55,8 +58,9 @@ def load_example_data(
         "The modality argument must be one of the following: " "raw_counts, clinical"
     )
 
-    assert cancer_type in [
+    assert dataset in [
         "synthetic",
+        "multifactor_synthetic",
         "TCGA-BRCA",
         "TCGA-COAD",
         "TCGA-LUAD",
@@ -66,14 +70,18 @@ def load_example_data(
         "TCGA-READ",
         "TCGA-SKCM",
     ], (
-        "The cancer_type argument must be one of the following: "
-        "syntetic, TCGA-BRCA, TCGA-COAD, TCGA-LUAD, TCGA-LUSC, "
+        "The dataset argument must be one of the following: "
+        "synthetic, multifactor_synthetic, TCGA-BRCA, TCGA-COAD, TCGA-LUAD, TCGA-LUSC, "
         "TCGA-PAAD, TCGA-PRAD, TCGA-READ, TCGA-SKCM"
     )
     # Load data
-    if cancer_type == "synthetic":
+    if dataset in ["synthetic", "multifactor_synthetic"]:
         datasets_path = Path(pydeseq2.__file__).parent.parent / "tests"
-        path_to_data = datasets_path / "data/single_factor/"
+        path_to_data = (
+            datasets_path / "data/single_factor/"
+            if dataset == "synthetic"
+            else datasets_path / "data/multi_factor/"
+        )
 
         if modality == "raw_counts":
             df = pd.read_csv(
@@ -93,14 +101,14 @@ def load_example_data(
 
         if modality == "raw_counts":
             df = pd.read_csv(
-                path_to_data / "Gene_expressions" / f"{cancer_type}_raw_RNAseq.tsv.gz",
+                path_to_data / "Gene_expressions" / f"{dataset}_raw_RNAseq.tsv.gz",
                 compression="gzip",
                 sep="\t",
                 index_col=0,
             ).T
         elif modality == "clinical":
             df = pd.read_csv(
-                path_to_data / "Clinical" / f"{cancer_type}_clinical.tsv.gz",
+                path_to_data / "Clinical" / f"{dataset}_clinical.tsv.gz",
                 compression="gzip",
                 sep="\t",
                 index_col=0,


### PR DESCRIPTION
In this PR, we add notebooks with bi-level multi-factor DEA examples. More precisely:

* `load_data_example` can now provide an example multi-factor synthetic example,
* two new notebooks were added: `PyDESeq2_minimal_multifactor_example.ipynb` and `PyDESeq2_multifactor_step_by_step_pipeline.ipynb`.

Note: there are now 4 example notebooks, which are potentially redundant. In a future PR, we should think of the best way to organize them, bearing the RTD documentation in mind.