### PR TITLE
DOC autosummary for api

### DIFF
--- a/docs/source/api/DeseqDataSet.rst
+++ b/docs/source/api/DeseqDataSet.rst
@@ -1,8 +1,0 @@
-pydeseq2.DeseqDataSet module
-============================
-
-.. automodule:: pydeseq2.DeseqDataSet
-   :members:
-   :undoc-members:
-   :show-inheritance:
-

--- a/docs/source/api/DeseqStats.rst
+++ b/docs/source/api/DeseqStats.rst
@@ -1,7 +1,0 @@
-pydeseq2.DeseqStats module
-==========================
-
-.. automodule:: pydeseq2.DeseqStats
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/api/grid_search.rst
+++ b/docs/source/api/grid_search.rst
@@ -1,7 +1,0 @@
-pydeseq2.grid\_search module
-============================
-
-.. automodule:: pydeseq2.grid_search
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -1,7 +1,7 @@
 import PyDESeq2 as pydeseq2
 
-PyDESeq2 package
-================
+PyDESeq2
+========
 
 .. currentmodule:: pydeseq2
 

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -1,12 +1,17 @@
+import PyDESeq2 as pydeseq2
+
 PyDESeq2 package
 ================
 
-.. toctree::
-   :glob:
-   :maxdepth: 2
+.. currentmodule:: pydeseq2
 
-   DeseqDataSet
-   DeseqStats
-   grid_search
-   preprocessing
-   utils
+
+.. autosummary::
+    :toctree: docstrings
+    :recursive:
+
+    DeseqDataSet.DeseqDataSet
+    DeseqStats.DeseqStats
+    ~utils
+    ~grid_search
+    ~preprocessing

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -1,4 +1,3 @@
-import PyDESeq2 as pydeseq2
 
 PyDESeq2
 ========

--- a/docs/source/api/preprocessing.rst
+++ b/docs/source/api/preprocessing.rst
@@ -1,7 +1,0 @@
-pydeseq2.preprocessing module
-=============================
-
-.. automodule:: pydeseq2.preprocessing
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/api/utils.rst
+++ b/docs/source/api/utils.rst
@@ -1,7 +1,0 @@
-pydeseq2.utils module
-=====================
-
-.. automodule:: pydeseq2.utils
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,9 +41,11 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinx.ext.ifconfig",
     "myst_parser",
+    "sphinx.ext.autosummary",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.intersphinx",
 ]
+
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
@@ -58,8 +60,12 @@ autodoc_default_options = {
     "show-inheritance": True,
     "members": True,
 }
+
 autoclass_content = "both"
 autodoc_typehints = "both"
+autosummary_generate = True
+autodoc_member_order = "groupwise"
+autodoc_docstring_signature = True
 
 
 # Napoleon settings


### PR DESCRIPTION
Adds the autosummary for the api: meaning the table with short description for docstrings

now it looks like this:
![image](https://user-images.githubusercontent.com/2219642/211848659-84bb6bae-94fb-442f-a57d-154f53966432.png)

and this:
![image](https://user-images.githubusercontent.com/2219642/211848832-b2e61735-712e-4b11-b82b-bdd741b68579.png)

