### PR TITLE
Fix: calculate Cooks distances with few samples 

### DIFF
--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -672,7 +672,7 @@ def trimmed_cell_variance(counts, cells):
     return varEst.max(axis=1)
 
 
-def trimmed_variance(x, trim=0.125, axis=1):
+def trimmed_variance(x, trim=0.125, axis=0):
     """Return trimmed variance.
 
      Compute the variance after trimming data of its smallest and largest quantiles.
@@ -683,10 +683,10 @@ def trimmed_variance(x, trim=0.125, axis=1):
         Data whose trimmed variance to compute.
 
     trim : float
-        Fraction of data to trim at each end. (default: 0.1).
+        Fraction of data to trim at each end. (default: 0.125).
 
     axis : int
-        Dimension along which to compute variance.
+        Dimension along which to compute variance. (default: 0).
 
     Returns
     -------

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -39,8 +39,7 @@ def load_example_data(
         Otherwise, must be a valid TCGA dataset. (default: "synthetic").
 
     debug : bool
-        If true, subsample 10 samples and 100 genes at random.
-        Only supported in "pooled" mode for now. (default: False).
+        If true, subsample 10 samples and 100 genes at random. (default: False).
 
     debug_seed : int
         Seed for the debug mode. (default: 42).

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -151,7 +151,7 @@ def test_indexes():
 
 
 def test_few_samples():
-    """Test that PyDESeq2 runs bug-free on a cohorts with less than 3 samples.
+    """Test that PyDESeq2 runs bug-free on cohorts with less than 3 samples.
     (Check in particular that DeseqDataSet.calculate_cooks() runs).
     TODO: refine this test to check the correctness of the output?
     """
@@ -174,7 +174,9 @@ def test_few_samples():
     clinical_df = clinical_df.loc[samples_to_keep]
 
     # Run analysis. Should not throw an error.
-    dds = DeseqDataSet(counts_df, clinical_df, design_factors="condition")
+    dds = DeseqDataSet(
+        counts_df, clinical_df, refit_cooks=True, design_factors="condition"
+    )
     dds.deseq2()
 
     res = DeseqStats(dds)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -148,3 +148,34 @@ def test_indexes():
             clinical_df,
             design_factors="condition",
         )
+
+
+def test_few_samples():
+    """Test that PyDESeq2 runs bug-free on a cohorts with less than 3 samples.
+    (Check in particular that DeseqDataSet.calculate_cooks() runs).
+    TODO: refine this test to check the correctness of the output?
+    """
+
+    counts_df = load_example_data(
+        modality="raw_counts",
+        dataset="synthetic",
+        debug=False,
+    )
+
+    clinical_df = load_example_data(
+        modality="clinical",
+        dataset="synthetic",
+        debug=False,
+    )
+
+    # Subsample two samples for each condition
+    samples_to_keep = ["sample1", "sample2", "sample99", "sample100"]
+    counts_df = counts_df.loc[samples_to_keep]
+    clinical_df = clinical_df.loc[samples_to_keep]
+
+    # Run analysis. Should not throw an error.
+    dds = DeseqDataSet(counts_df, clinical_df, design_factors="condition")
+    dds.deseq2()
+
+    res = DeseqStats(dds)
+    res.summary()


### PR DESCRIPTION
This PR aims to fix the bug described in Issue #43.

The issue seemed to be that the summation was done on the wrong axis in the `trimmed_variance` function, called through `robust_method_of_moments_disp` in the  `calculate_cooks` method of the `DeseqDataSet` class.