### PR TITLE
Refactor: remove deprecated `_change_lfc_sign` attribute of the `DeseqStats` class

### DIFF
--- a/pydeseq2/DeseqStats.py
+++ b/pydeseq2/DeseqStats.py
@@ -185,7 +185,6 @@ class DeseqStats:
             )
             self.LFCs.iloc[:, 0] += self.LFCs.iloc[:, self.contrast_idx]
             self.LFCs.iloc[:, self.contrast_idx] *= -1
-            print(self.LFCs.columns[self.contrast_idx])
         # Set a flag to indicate that LFCs are unshrunk
         self.shrunk_LFCs = False
         self.n_processes = get_num_processes(n_cpus)

--- a/pydeseq2/DeseqStats.py
+++ b/pydeseq2/DeseqStats.py
@@ -190,7 +190,6 @@ class DeseqStats:
         self.n_processes = get_num_processes(n_cpus)
         self.batch_size = batch_size
         self.joblib_verbosity = joblib_verbosity
-        self._change_lfc_sign = False
 
     def summary(self):
         """Run the statistical analysis.
@@ -254,12 +253,6 @@ class DeseqStats:
             .multiply(self.dds.size_factors, 0)
             .values
         )
-
-        # If the contrast implies a different reference level than the one from the
-        # design matrix, change lfc signs. Do this *after* the means were computed
-        # (otherwise we would need)
-        if self._change_lfc_sign:
-            self.LFCs.iloc[:, self.contrast_idx] *= -1
 
         # Set regularization factors.
         if self.prior_disp_var is not None:


### PR DESCRIPTION
With PR #40 the `_change_lfc_sign` attribute of the `DeseqStats` class has deprecated. This PR removes it, along with a useless print statement (intended for debugging only). 