### PR TITLE
Fix: raise error when cooks outliers should have been refitted but were not

### DIFF
--- a/pydeseq2/DeseqStats.py
+++ b/pydeseq2/DeseqStats.py
@@ -193,6 +193,15 @@ class DeseqStats:
         self.joblib_verbosity = joblib_verbosity
         self._change_lfc_sign = False
 
+        # If the `refit_cooks` attribute of the dds object is True, check that outliers
+        # were actually refitted.
+        if dds.refit_cooks:
+            assert hasattr(dds, "replaced"), (
+                "dds has 'refit_cooks' set to True but Cooks outliers have not been "
+                "refitted. Please run 'dds.refit()' first or set 'dds.refit_cooks' "
+                "to False."
+            )
+
     def summary(self):
         """Run the statistical analysis.
 

--- a/pydeseq2/DeseqStats.py
+++ b/pydeseq2/DeseqStats.py
@@ -193,8 +193,10 @@ class DeseqStats:
 
         # If the `refit_cooks` attribute of the dds object is True, check that outliers
         # were actually refitted.
-        if dds.refit_cooks:
-            assert hasattr(dds, "replaced"), (
+        try:
+            dds.replaced
+        except AttributeError:
+            raise AttributeError(
                 "dds has 'refit_cooks' set to True but Cooks outliers have not been "
                 "refitted. Please run 'dds.refit()' first or set 'dds.refit_cooks' "
                 "to False."

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -148,3 +148,37 @@ def test_indexes():
             clinical_df,
             design_factors="condition",
         )
+
+
+def test_cooks_not_refitted():
+    """Test that an AssertionError is thrown when a `DeseqStats` object is initialized
+    from a `DeseqDataSet` whose `refit_cooks` attribute is set to True, but whose
+    Cooks outliers were not actually refitted."""
+
+    counts_df = load_example_data(
+        modality="raw_counts",
+        dataset="synthetic",
+        debug=False,
+    )
+
+    clinical_df = load_example_data(
+        modality="clinical",
+        dataset="synthetic",
+        debug=False,
+    )
+
+    # Run analysis
+    dds = DeseqDataSet(
+        counts_df,
+        clinical_df,
+        refit_cooks=False,
+        design_factors="condition",
+    )
+    dds.deseq2()
+
+    # Set refit_cooks to True even though outliers were not refitted
+    dds.refit_cooks = True
+
+    with pytest.raises(AssertionError):
+        stat_res = DeseqStats(dds)
+        stat_res.summary()

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -179,7 +179,7 @@ def test_cooks_not_refitted():
     # Set refit_cooks to True even though outliers were not refitted
     dds.refit_cooks = True
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(AttributeError):
         stat_res = DeseqStats(dds)
         stat_res.summary()
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -151,7 +151,7 @@ def test_indexes():
 
 
 def test_cooks_not_refitted():
-    """Test that an AssertionError is thrown when a `DeseqStats` object is initialized
+    """Test that an AttributeError is thrown when a `DeseqStats` object is initialized
     from a `DeseqDataSet` whose `refit_cooks` attribute is set to True, but whose
     Cooks outliers were not actually refitted."""
 


### PR DESCRIPTION
This PR addresses issue #46 by raising an `AssertionError` if one tries to initialize a `DeseqStats` object  from a `DeseqDataSet` with `refit_cooks=True` but whose outliers were not refit. 

This is detected by checking that the `DeseqDataSet` has a `replaced` attribute. 

A corresponding pytest was also added.

Closes #46.