### PR TITLE
Fix add missing `joblib_verbosity` argument in `fit_genewise_dispersions`

### DIFF
--- a/pydeseq2/DeseqDataSet.py
+++ b/pydeseq2/DeseqDataSet.py
@@ -327,7 +327,11 @@ class DeseqDataSet:
         print("Fitting dispersions...")
         start = time.time()
         with parallel_backend("loky", inner_max_num_threads=1):
-            res = Parallel(n_jobs=self.n_processes, batch_size=self.batch_size)(
+            res = Parallel(
+                n_jobs=self.n_processes,
+                verbose=self.joblib_verbosity,
+                batch_size=self.batch_size,
+            )(
                 delayed(fit_alpha_mle)(
                     counts=counts_nonzero[:, i],
                     design_matrix=X,


### PR DESCRIPTION
This PR adds the `joblib_verbosity` attribute of `DeseqDataSet`, which allows to control the level of verbosity of `Parallel` worker pools, as an argument in the main loop of `fit_genewise_dispersions`, from which it was missing.