### PR TITLE
BUG set `dds.replaced` to `False` if cohorts don't have enough samples

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -618,7 +618,7 @@ class DeseqDataSet:
         """
         # Replace outlier counts
         self._replace_outliers()
-        print(f"Refitting {self.replaced.sum()} outliers.\n")
+        print(f"Refitting {self.replaced.sum()} outlier genes.\n")
 
         if self.replaced.sum() > 0:
             # Refit dispersions and LFCs for genes that had outliers replaced
@@ -654,6 +654,12 @@ class DeseqDataSet:
             self.design_matrix[self.design_matrix.columns[-1]].value_counts()
             >= self.min_replicates
         )
+
+        if n_or_more.sum() == 0:
+            # No sample can be replaced. Set self.replaced to False and exit.
+            self.replaced = pd.Series(False, index=self.counts.columns)
+            return
+
         self.replaceable = pd.Series(
             n_or_more[self.design_matrix[self.design_matrix.columns[-1]]]
         )

--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -420,7 +420,10 @@ class DeseqStats:
         for i, cutoff in enumerate(cutoffs):
             use = (self.base_mean >= cutoff) & (~self.p_values.isna())
             U2 = self.p_values[use]
-            result.loc[use, i] = multipletests(U2, alpha=self.alpha, method="fdr_bh")[1]
+            if not U2.empty:
+                result.loc[use, i] = multipletests(
+                    U2, alpha=self.alpha, method="fdr_bh"
+                )[1]
 
         num_rej = (result < self.alpha).sum(0)
         lowess = sm.nonparametric.lowess(num_rej, theta, frac=1 / 5)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -207,6 +207,9 @@ def test_few_samples():
     counts_df = counts_df.loc[samples_to_keep]
     clinical_df = clinical_df.loc[samples_to_keep]
 
+    # Introduce an outlier
+    counts_df.iloc[0, 0] = 1000
+
     # Run analysis. Should not throw an error.
     dds = DeseqDataSet(
         counts_df, clinical_df, refit_cooks=True, design_factors="condition"
@@ -215,3 +218,6 @@ def test_few_samples():
 
     res = DeseqStats(dds)
     res.summary()
+
+    # Check that no gene was refit, as there are not enough samples.
+    assert dds.replaced.sum() == 0


### PR DESCRIPTION
#### Reference Issue or PRs

Fixes #69.


#### What does your PR implement? Be specific.

- If no cohort has enough samples to refit, set the `replaced` attribute to `False` for all genes in a `DeseqDataSet`,
- Skip empty cutoffs in `DeseqStats`'s `_independent_filtering`,
- Add a unit test to check that the issue described in #69 no longer occurs. 
