### PR TITLE
Moving docs' requirements into the actual docs' requirements file

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,5 @@ docutils==0.16
 sphinx_click==3.1.0
 sphinx_gallery==0.11.1
 sphinxcontrib-bibtex==2.5.0
+gitpython>=3.1.27
+matplotlib>=3.6.2  # not sure why sphinx_gallery does not work without it

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,4 +11,3 @@ sphinx_click==3.1.0
 sphinx_gallery==0.11.1
 sphinxcontrib-bibtex==2.5.0
 gitpython>=3.1.27
-matplotlib>=3.6.2  # not sure why sphinx_gallery does not work without it

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "scikit-learn>=1.1.0",
         "scipy>=1.8.0",
         "statsmodels",
-        "matplotlib>=3.6.2",   # not sure why sphinx_gallery does not work without it
+        "matplotlib>=3.6.2",  # not sure why sphinx_gallery does not work without it
     ],  # external packages as dependencies
     extras_require={
         "dev": ["pytest>=6.2.4", "pre-commit>=2.13.0", "numpydoc"],

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "scikit-learn>=1.1.0",
         "scipy>=1.8.0",
         "statsmodels",
-        "matplotlib>=3.6.2"  # not sure why sphinx_gallery does not work without it
+        "matplotlib>=3.6.2",   # not sure why sphinx_gallery does not work without it
     ],  # external packages as dependencies
     extras_require={
         "dev": ["pytest>=6.2.4", "pre-commit>=2.13.0", "numpydoc"],

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,6 @@ setup(
         "scikit-learn>=1.1.0",
         "scipy>=1.8.0",
         "statsmodels",
-        "gitpython>=3.1.27",
-        "matplotlib>=3.6.2",  # not sure why sphinx_gallery does not work without it
     ],  # external packages as dependencies
     extras_require={
         "dev": ["pytest>=6.2.4", "pre-commit>=2.13.0", "numpydoc"],

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "scikit-learn>=1.1.0",
         "scipy>=1.8.0",
         "statsmodels",
+        "matplotlib>=3.6.2"  # not sure why sphinx_gallery does not work without it
     ],  # external packages as dependencies
     extras_require={
         "dev": ["pytest>=6.2.4", "pre-commit>=2.13.0", "numpydoc"],


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://pydeseq2.readthedocs.io/en/latest/usage/contributing.html
Make sure that you have added unit tests if applicable.
-->

#### Reference Issue or PRs

This PR is not linked to an existing issue.


#### What does your PR implement? Be specific.

This PR moves the specific requirements of the documentation (`matplotlib` and `gitpython`) which are currently in the `setup.py` file to the `docs/requirements.txt` file, which is more appropriate as they are not used elsewhere.