### PR TITLE
[FIX] Adds docs' auto-generated rst files to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Autobuild docs
+docs/source/api/docstrings
+docs/source/auto_examples


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://pydeseq2.readthedocs.io/en/latest/usage/contributing.html
Make sure that you have added unit tests if applicable.
-->

#### Reference Issue or PRs
<!--
If this PR is related to an existing issue or PR please reference it, eg:
Fixes #1234.
You can use github keywords as described:
https://github.com/blog/1506-closing-issues-via-pull-requests
-->

In #66 and #68 , the `.rst` files automatically created by sphinx when parsing the docstrings were added to the PR.


#### What does your PR implement? Be specific.

This PR adds the two following folders to the gitignore:
`docs/source/api/docstrings`, 
`docs/source/auto_examples`,
thereby preventing any accidental git tracking of these auto-generated files
