### PR TITLE
CI add more versions of python to the github workflow

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -23,8 +23,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install isort black==22.3.0
-          pip install flake8
           pip install pre-commit
           pip install -e ."[dev]"
           pip install -r docs/requirements.txt

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -10,12 +10,16 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   run_tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.python }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ If you're interested in contributing or want access to the development version, 
 
 The list of package version requirements is available in `setup.py`.
 
-For reference, the code was tested with python 3.8 and the following package versions:
+For reference, the code is being tested in a github workflow (CI) with python
+3.8 -- 3.11 and the following package versions:
 ```
 - numpy 1.23.0
 - pandas 1.4.3

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you're interested in contributing or want access to the development version, 
 The list of package version requirements is available in `setup.py`.
 
 For reference, the code is being tested in a github workflow (CI) with python
-3.8 -- 3.11 and the following package versions:
+3.8-3.11 and the following package versions:
 ```
 - numpy 1.23.0
 - pandas 1.4.3


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://pydeseq2.readthedocs.io/en/latest/usage/contributing.html
Make sure that you have added unit tests if applicable.
-->
Python 3.8 is supported until October 2024. To ensure the long term support we need to start testing for newer versions of Python as well

#### Reference Issue or PRs
<!--
If this PR is related to an existing issue or PR please reference it, eg:
Fixes #1234.
You can use github keywords as described:
https://github.com/blog/1506-closing-issues-via-pull-requests
-->
NA

#### What does your PR implement? Be specific.
CI check for python 3.9 and 3.10 and 3.11
