### PR TITLE
DOC fix broken RTD example gallery

### DIFF
--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -73,16 +73,16 @@ def load_example_data(
     if dataset == "synthetic":
         path_to_data = datasets_path / "synthetic"
         if Path(path_to_data).is_dir():
-            path_to_data_counts = path_to_data / "test_counts.csv"
-            path_to_data_clinical = path_to_data / "test_clinical.csv"
+            path_to_data_counts = str(path_to_data / "test_counts.csv")
+            path_to_data_clinical = str(path_to_data / "test_clinical.csv")
         else:
             # if the path does not exist (as is the case in RDT) load it from github
             url_to_data = (
                 "https://raw.githubusercontent.com/owkin/"
                 "PyDESeq2/main/datasets/synthetic/"
             )
-            path_to_data_counts = Path(url_to_data + "/test_counts.csv")
-            path_to_data_clinical = Path(url_to_data + "/test_clinical.csv")
+            path_to_data_counts = url_to_data + "/test_counts.csv"
+            path_to_data_clinical = url_to_data + "/test_clinical.csv"
 
         if modality == "raw_counts":
             df = pd.read_csv(

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -73,6 +73,8 @@ def load_example_data(
     if dataset == "synthetic":
         path_to_data = datasets_path / "synthetic"
         if Path(path_to_data).is_dir():
+            # Cast the Paths to strings to have coherent types wrt to the url case (that
+            # does not handle Paths), else mypy throws an error.
             path_to_data_counts = str(path_to_data / "test_counts.csv")
             path_to_data_clinical = str(path_to_data / "test_clinical.csv")
         else:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,3 +1,6 @@
+import pathlib
+from unittest import mock
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -240,3 +243,29 @@ def test_few_samples():
 
     # Check that no gene was refit, as there are not enough samples.
     assert dds.varm["replaced"].sum() == 0
+
+
+# Test data loading from outside the package (e.g. on RTF)
+@mock.patch("pathlib.Path.is_dir")
+def test_rtd_example_data_loading(mocked_function):
+    """
+    Test that load_example_data still works when run from a place where the ``datasets``
+    directory is not accessible, as is when the documentation is built on readthedocs.
+    """
+
+    # Mock the output of is_dir() as False to emulate not having access to the
+    # ``datasets`` directory
+    pathlib.Path.is_dir.return_value = False
+
+    # Try loading data. Ignore flake8 "variable is assigned to but never used" error.
+    counts_df = load_example_data(  # noqa: F841
+        modality="raw_counts",
+        dataset="synthetic",
+        debug=False,
+    )
+
+    clinical_df = load_example_data(  # noqa: F841
+        modality="clinical",
+        dataset="synthetic",
+        debug=False,
+    )

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,6 +1,3 @@
-import pathlib
-from unittest import mock
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -243,29 +240,3 @@ def test_few_samples():
 
     # Check that no gene was refit, as there are not enough samples.
     assert dds.varm["replaced"].sum() == 0
-
-
-# Test data loading from outside the package (e.g. on RTF)
-@mock.patch("pathlib.Path.is_dir")
-def test_rtd_example_data_loading(mocked_function):
-    """
-    Test that load_example_data still works when run from a place where the ``datasets``
-    directory is not accessible, as is when the documentation is built on readthedocs.
-    """
-
-    # Mock the output of is_dir() as False to emulate not having access to the
-    # ``datasets`` directory
-    pathlib.Path.is_dir.return_value = False
-
-    # Try loading data. Ignore flake8 "variable is assigned to but never used" error.
-    counts_df = load_example_data(  # noqa: F841
-        modality="raw_counts",
-        dataset="synthetic",
-        debug=False,
-    )
-
-    clinical_df = load_example_data(  # noqa: F841
-        modality="clinical",
-        dataset="synthetic",
-        debug=False,
-    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,8 +35,9 @@ def test_nb_nll_moments(mu, alpha):
 
 # Test data loading from outside the package (e.g. on RTF)
 @pytest.mark.parametrize("modality", ["raw_counts", "clinical"])
+@pytest.mark.parametrize("mocked_dir_flag", [True, False])
 @mock.patch("pathlib.Path.is_dir")
-def test_rtd_example_data_loading(mocked_function, modality):
+def test_rtd_example_data_loading(mocked_function, modality, mocked_dir_flag):
     """
     Test that load_example_data still works when run from a place where the ``datasets``
     directory is not accessible, as is when the documentation is built on readthedocs.
@@ -44,7 +45,7 @@ def test_rtd_example_data_loading(mocked_function, modality):
 
     # Mock the output of is_dir() as False to emulate not having access to the
     # ``datasets`` directory
-    pathlib.Path.is_dir.return_value = [False, True]
+    pathlib.Path.is_dir.return_value = mocked_dir_flag
 
     # Try loading data.
     load_example_data(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,10 @@
+import pathlib
+from unittest import mock
+
 import numpy as np
 import pytest
 
+from pydeseq2.utils import load_example_data
 from pydeseq2.utils import nb_nll
 
 
@@ -27,3 +31,29 @@ def test_nb_nll_moments(mu, alpha):
     assert np.abs(diff) < 0.2 * deviation
     error_var = np.abs(sample.var() - var_th) / var_th
     assert error_var < 1 / np.sqrt(n_montecarlo)
+
+
+# Test data loading from outside the package (e.g. on RTF)
+@mock.patch("pathlib.Path.is_dir")
+def test_rtd_example_data_loading(mocked_function):
+    """
+    Test that load_example_data still works when run from a place where the ``datasets``
+    directory is not accessible, as is when the documentation is built on readthedocs.
+    """
+
+    # Mock the output of is_dir() as False to emulate not having access to the
+    # ``datasets`` directory
+    pathlib.Path.is_dir.return_value = False
+
+    # Try loading data. Ignore flake8 "variable is assigned to but never used" error.
+    counts_df = load_example_data(  # noqa: F841
+        modality="raw_counts",
+        dataset="synthetic",
+        debug=False,
+    )
+
+    clinical_df = load_example_data(  # noqa: F841
+        modality="clinical",
+        dataset="synthetic",
+        debug=False,
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,6 +34,7 @@ def test_nb_nll_moments(mu, alpha):
 
 
 # Test data loading from outside the package (e.g. on RTF)
+@pytest.mark.parametrize("return_value", [True, False])
 @mock.patch("pathlib.Path.is_dir")
 def test_rtd_example_data_loading(mocked_function):
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,7 +44,7 @@ def test_rtd_example_data_loading(mocked_function, modality):
 
     # Mock the output of is_dir() as False to emulate not having access to the
     # ``datasets`` directory
-    pathlib.Path.is_dir.return_value = False
+    pathlib.Path.is_dir.return_value = [False, True]
 
     # Try loading data.
     load_example_data(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,9 +34,9 @@ def test_nb_nll_moments(mu, alpha):
 
 
 # Test data loading from outside the package (e.g. on RTF)
-@pytest.mark.parametrize("return_value", [True, False])
+@pytest.mark.parametrize("modality", ["raw_counts", "clinical"])
 @mock.patch("pathlib.Path.is_dir")
-def test_rtd_example_data_loading(mocked_function):
+def test_rtd_example_data_loading(mocked_function, modality):
     """
     Test that load_example_data still works when run from a place where the ``datasets``
     directory is not accessible, as is when the documentation is built on readthedocs.
@@ -46,15 +46,9 @@ def test_rtd_example_data_loading(mocked_function):
     # ``datasets`` directory
     pathlib.Path.is_dir.return_value = False
 
-    # Try loading data. Ignore flake8 "variable is assigned to but never used" error.
-    counts_df = load_example_data(  # noqa: F841
-        modality="raw_counts",
-        dataset="synthetic",
-        debug=False,
-    )
-
-    clinical_df = load_example_data(  # noqa: F841
-        modality="clinical",
+    # Try loading data.
+    load_example_data(
+        modality=modality,
         dataset="synthetic",
         debug=False,
     )


### PR DESCRIPTION
#### What does your PR implement? Be specific.

This PR fixes the example gallery which causes the docs not to compile on readthedocs. This is due to a data importing issue after merging #68 (pandas won't load a csv from an url provided in the form of a `Path`).

A unit test was added to `test_utils.py` to check that `load_example_data` correctly retrieves data from github when the `datasets` directory is not accessible (as when building the docs on RTD). 