### PR TITLE
BUG typo in attribute name

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -726,7 +726,7 @@ class DeseqDataSet(ad.AnnData):
         self.new_all_zeroes_genes = self.counts_to_refit.var_names[new_all_zeroes]
         self.counts_to_refit = self.counts_to_refit[:, ~new_all_zeroes].copy()
 
-        if isinstance(self.new_all_zero_genes, pd.MultiIndex):
+        if isinstance(self.new_all_zeroes_genes, pd.MultiIndex):
             raise ValueError
 
         sub_dds = DeseqDataSet(


### PR DESCRIPTION
#### What does your PR implement? Be specific.

This PR fixes a small typo in an attribute name (`self.new_all_zero_genes` instead of `self.new_all_zeroes_genes`).
