### PR TITLE
BUG correct typo in `fit_dispersion_prior`

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -428,7 +428,7 @@ class DeseqDataSet(ad.AnnData):
 
         # Exclude genes with all zeroes
         num_genes = len(self.non_zero_genes)
-        num_vars = self.n_vars
+        num_vars = self.obsm["design_matrix"].shape[-1]
 
         # Fit dispersions to the curve, and compute log residuals
         disp_residuals = np.log(


### PR DESCRIPTION
#### What does your PR implement? Be specific.

This PR corrects a typo which caused the dispersion prior estimate to be incorrect.