### PR TITLE
build: remove jupyter from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         "anndata==0.8.0",
+        "ipython",
         "numpy>=1.23.0",
         "pandas>=1.4.0",
         "scikit-learn>=1.1.0",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         "anndata==0.8.0",
-        "jupyter",
         "numpy>=1.23.0",
         "pandas>=1.4.0",
         "scikit-learn>=1.1.0",


### PR DESCRIPTION
#### Reference Issue or PRs
Fixes #113

#### What does your PR implement? Be specific.
Removes `jupyter` from the `setup.py` requirements and replace it with `ipython` (used in `DeseqStats.summary()`).

