### PR TITLE
BUG fix `deseq2_norm` bug when applied to a pandas dataframe

### DIFF
--- a/pydeseq2/preprocessing.py
+++ b/pydeseq2/preprocessing.py
@@ -12,7 +12,7 @@ def deseq2_norm(counts: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
 
     Parameters
     ----------
-    counts : ndarray
+    counts : pandas.DataFrame
             Raw counts. One column per gene, one row per sample.
 
     Returns
@@ -32,7 +32,10 @@ def deseq2_norm(counts: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
     # Filter out genes with -∞ log means
     filtered_genes = ~np.isinf(logmeans)
     # Subtract filtered log means from log counts
-    log_ratios = log_counts[:, filtered_genes] - logmeans[filtered_genes]
+    if isinstance(log_counts, pd.DataFrame):
+        log_ratios = log_counts.loc[:, filtered_genes] - logmeans[filtered_genes]
+    else:
+        log_ratios = log_counts[:, filtered_genes] - logmeans[filtered_genes]
     # Compute sample-wise median of log ratios
     log_medians = np.median(log_ratios, axis=1)
     # Return raw counts divided by size factors (exponential of log ratios)

--- a/pydeseq2/preprocessing.py
+++ b/pydeseq2/preprocessing.py
@@ -1,10 +1,13 @@
 from typing import Tuple
+from typing import Union
 
 import numpy as np
 import pandas as pd
 
 
-def deseq2_norm(counts: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
+def deseq2_norm(
+    counts: Union[pd.DataFrame, np.ndarray]
+) -> Tuple[Union[pd.DataFrame, np.ndarray], Union[pd.DataFrame, np.ndarray]]:
     """
     Return normalized counts and size_factors.
 
@@ -12,16 +15,16 @@ def deseq2_norm(counts: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
 
     Parameters
     ----------
-    counts : pandas.DataFrame
+    counts : pandas.DataFrame or ndarray
             Raw counts. One column per gene, one row per sample.
 
     Returns
     -------
-    deseq2_counts : pandas.DataFrame
+    deseq2_counts : pandas.DataFrame or ndarray
         DESeq2 normalized counts.
         One column per gene, rows are indexed by sample barcodes.
 
-    size_factors : pandas.DataFrame
+    size_factors : pandas.DataFrame or ndarray
         DESeq2 normalization factors.
     """
 

--- a/tests/test_pydeseq2.py
+++ b/tests/test_pydeseq2.py
@@ -8,6 +8,7 @@ import pandas as pd
 import tests
 from pydeseq2.dds import DeseqDataSet
 from pydeseq2.ds import DeseqStats
+from pydeseq2.preprocessing import deseq2_norm
 from pydeseq2.utils import load_example_data
 
 # Single-factor tests
@@ -480,3 +481,34 @@ def test_ref_level():
             lambda x: 1 if x == "X" else 0 if x == "Y" else np.NaN
         )
     ).all()
+
+
+def test_deseq2_norm():
+    """Test that deseq2_norm() called on a pandas dataframe outputs the same results as
+    DeseqDataSet.fit_size_factors()
+    """
+    counts_df = load_example_data(
+        modality="raw_counts",
+        dataset="synthetic",
+        debug=False,
+    )
+
+    clinical_df = load_example_data(
+        modality="clinical",
+        dataset="synthetic",
+        debug=False,
+    )
+
+    # Fit size factors from DeseqDataSet
+    dds = DeseqDataSet(counts=counts_df, clinical=clinical_df)
+    dds.fit_size_factors()
+    s1 = dds.obsm["size_factors"]
+
+    # Fit size factors from counts directly
+    s2 = deseq2_norm(counts_df)
+
+    np.testing.assert_almost_equal(
+        s1,
+        s2.values,
+        decimal=8,
+    )

--- a/tests/test_pydeseq2.py
+++ b/tests/test_pydeseq2.py
@@ -505,7 +505,7 @@ def test_deseq2_norm():
     s1 = dds.obsm["size_factors"]
 
     # Fit size factors from counts directly
-    s2 = deseq2_norm(counts_df)
+    s2 = deseq2_norm(counts_df)[1]
 
     np.testing.assert_almost_equal(
         s1,

--- a/tests/test_pydeseq2.py
+++ b/tests/test_pydeseq2.py
@@ -509,6 +509,6 @@ def test_deseq2_norm():
 
     np.testing.assert_almost_equal(
         s1,
-        s2.values,
+        s2,
         decimal=8,
     )


### PR DESCRIPTION
#### Reference Issue or PRs
Fixes #122 

#### What does your PR implement? Be specific.
This PR:
- Fixes the bug described in #122 appearing when calling `deseq2_norm` on a pandas dataframe, by checking whether the argument is a dataframe (in which case indexing is done with `.loc` or a ndarray).
- Implements a test to check that we get the same results in both cases.