### PR TITLE
BUG wrong `lfc_shrink` sign display

### DIFF
--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -386,6 +386,8 @@ class DeseqStats:
             # Get the corrresponding factor, tested and reference levels of the shrunk
             # coefficient
             split_coeff = coeff.split("_")
+            # coeffs are of the form "factor_A_vs_B", hence "factor" is split_coeff[0],
+            # "A" is split_coeff[1] and "B" split_coeff[3]
             print(
                 f"Shrunk Log2 fold change & Wald test p-value: "
                 f"{split_coeff[0]} {split_coeff[1]} vs {split_coeff[3]}"

--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -275,7 +275,8 @@ class DeseqStats:
         Parameters
         ----------
         coeff : str or None
-            The LFC coefficient to shrink.
+            The LFC coefficient to shrink. If set to ``None``, the method will try to
+            shrink the coefficient corresponding to the ``contrast`` attribute.
             If the desired coefficient is not available, it may be set from the
             :class:`pydeseq2.dds.DeseqDataSet` argument ``ref_level``.
             (default: ``None``).

--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -267,25 +267,43 @@ class DeseqStats:
             self.statistics.loc[self.dds.new_all_zeroes_genes] = 0.0
             self.p_values.loc[self.dds.new_all_zeroes_genes] = 1.0
 
-    def lfc_shrink(self, coeff: str) -> None:
+    def lfc_shrink(self, coeff: Optional[str] = None) -> None:
         """LFC shrinkage with an apeGLM prior :cite:p:`DeseqStats-zhu2019heavy`.
 
         Shrinks LFCs using a heavy-tailed Cauchy prior, leaving p-values unchanged.
 
         Parameters
         ----------
-        coeff : str
+        coeff : str or None
             The LFC coefficient to shrink.
             If the desired coefficient is not available, it may be set from the
             :class:`pydeseq2.dds.DeseqDataSet` argument ``ref_level``.
+            (default: ``None``).
         """
 
-        if coeff not in self.LFC.columns:
+        contrast_level = f"{self.contrast[0]}_{self.contrast[1]}_vs_{self.contrast[2]}"
+
+        if coeff is not None:
+            if coeff not in self.LFC.columns:
+                split_coeff = coeff.split("_")
+                raise KeyError(
+                    f"The coeff argument '{coeff}' should be one the LFC columns. "
+                    f"The available LFC coeffs are {self.LFC.columns[1:]}. "
+                    f"If the desired coefficient is not available, please set "
+                    f"`ref_level = [{split_coeff[0]}, {split_coeff[3]}]` "
+                    f"in DeseqDataSet and rerun."
+                )
+        elif contrast_level not in self.LFC.columns:
             raise KeyError(
-                f"The coeff argument ('{coeff}') should be one the LFC columns. "
-                f"If not available,  it can be set from DeseqDataSet's `ref_level` "
-                f"argument."
+                f"lfc_shrink's coeff argument was set to None, but the coefficient "
+                f"corresponding to the contrast {self.contrast} is not available."
+                f"The available LFC coeffs are {self.LFC.columns[1:]}. "
+                f"If the desired coefficient is not available, please set "
+                f"`ref_level = [{self.contrast[0]}, {self.contrast[2]}]` "
+                f"in DeseqDataSet and rerun."
             )
+        else:
+            coeff = contrast_level
 
         coeff_idx = self.LFC.columns.get_loc(coeff)
 
@@ -356,9 +374,12 @@ class DeseqStats:
             self.results_df["log2FoldChange"] = self.LFC.iloc[:, coeff_idx] / np.log(2)
             self.results_df["lfcSE"] = self.SE / np.log(2)
 
+            # Get the corrresponding factor, tested and reference levels of the shrunk
+            # coefficient
+            split_coeff = coeff.split("_")
             print(
                 f"Shrunk Log2 fold change & Wald test p-value: "
-                f"{self.contrast[0]} {self.contrast[1]} vs {self.contrast[2]}"
+                f"{split_coeff[0]} {split_coeff[1]} vs {split_coeff[3]}"
             )
 
             display(self.results_df)

--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -287,13 +287,21 @@ class DeseqStats:
         if coeff is not None:
             if coeff not in self.LFC.columns:
                 split_coeff = coeff.split("_")
-                raise KeyError(
-                    f"The coeff argument '{coeff}' should be one the LFC columns. "
-                    f"The available LFC coeffs are {self.LFC.columns[1:]}. "
-                    f"If the desired coefficient is not available, please set "
-                    f"`ref_level = [{split_coeff[0]}, {split_coeff[3]}]` "
-                    f"in DeseqDataSet and rerun."
-                )
+                if len(split_coeff) == 4:
+                    raise KeyError(
+                        f"The coeff argument '{coeff}' should be one the LFC columns. "
+                        f"The available LFC coeffs are {self.LFC.columns[1:]}. "
+                        f"If the desired coefficient is not available, please set "
+                        f"`ref_level = [{split_coeff[0]}, {split_coeff[3]}]` "
+                        f"in DeseqDataSet and rerun."
+                    )
+                else:
+                    raise KeyError(
+                        f"The coeff argument '{coeff}' should be one the LFC columns. "
+                        f"The available LFC coeffs are {self.LFC.columns[1:]}. "
+                        f"If the desired coefficient is not available, please set the "
+                        f"appropriate`ref_level` in DeseqDataSet and rerun."
+                    )
         elif contrast_level not in self.LFC.columns:
             raise KeyError(
                 f"lfc_shrink's coeff argument was set to None, but the coefficient "

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -165,12 +165,22 @@ def test_lfc_shrinkage_coeff():
     )
     dds.deseq2()
 
-    res = DeseqStats(dds)
-    res.summary()
-    res.lfc_shrink(coeff=None)
+    # Check that coeff=None gives the same results as the default
+    # coefficient condition_B_vs_A
+    res_1 = DeseqStats(dds)
+    res_1.summary()
+    res_1.lfc_shrink(coeff=None)
+    shrunk_lfcs_1 = res_1.results_df["log2FoldChange"].copy()
+
+    res_2 = DeseqStats(dds)
+    res_2.summary()
+    res_2.lfc_shrink(coeff="condition_B_vs_A")
+    shrunk_lfcs_2 = res_2.results_df["log2FoldChange"].copy()
+
+    assert (shrunk_lfcs_1 == shrunk_lfcs_2).all()
 
     with pytest.raises(KeyError):
-        res.lfc_shrink(coeff="this_coeff_does_not_exist")
+        res_1.lfc_shrink(coeff="this_coeff_does_not_exist")
 
 
 def test_indexes():

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -167,7 +167,7 @@ def test_lfc_shrinkage_coeff():
 
     res = DeseqStats(dds)
     res.summary()
-    res.lfc_shrink(coeff="None")
+    res.lfc_shrink(coeff=None)
 
     with pytest.raises(KeyError):
         res.lfc_shrink(coeff="this_coeff_does_not_exist")

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -145,7 +145,7 @@ def test_reference_level():
 
 def test_lfc_shrinkage_coeff():
     """Test that a KeyError is thrown when attempting to shrink an unexisting LFC
-    coefficient.
+    coefficient, but that setting coeff=None runs bug-free.
     """
 
     counts_df = load_example_data(
@@ -167,6 +167,8 @@ def test_lfc_shrinkage_coeff():
 
     res = DeseqStats(dds)
     res.summary()
+    res.lfc_shrink(coeff="None")
+
     with pytest.raises(KeyError):
         res.lfc_shrink(coeff="this_coeff_does_not_exist")
 


### PR DESCRIPTION
#### Reference Issue or PRs
Fixes #121 


#### What does your PR implement? Be specific.
This PR addresses #121 (wrong display of shrunk factors). More precisely:
- the message output by `lfc_shrink` was fixed to match the coefficient that was actually shrunk
- when the coefficient is not available, the error message now explains how to set `ref_level` in `DeseqDataSet`
- it is now possible to set `coeff=None`
- `coeff=None` is tested in `test_edge_cases.py`
