### PR TITLE
BUG `beta` not initialized in `irls_solver` when the design is not a full rank matrix

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -217,6 +217,9 @@ class DeseqDataSet(ad.AnnData):
             intercept=True,
         )
 
+        # Check that the design matrix has full rank
+        self._check_full_rank_design()
+
         self.min_mu = min_mu
         self.min_disp = min_disp
         self.max_disp = np.maximum(max_disp, self.n_obs)
@@ -994,3 +997,14 @@ class DeseqDataSet(ad.AnnData):
 
         # Store normalized counts
         self.layers["normed_counts"] = self.X / self.obsm["size_factors"][:, None]
+
+    def _check_full_rank_design(self):
+        """Check that the design matrix has full column rank."""
+        rank = np.linalg.matrix_rank(self.obsm["design_matrix"])
+        num_vars = self.obsm["design_matrix"].shape[1]
+
+        if rank < num_vars:
+            raise ValueError(
+                "The design matrix is not full rank, so the model cannot be "
+                "fitted. Please remove one or more variables from the design."
+            )

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -1006,5 +1006,6 @@ class DeseqDataSet(ad.AnnData):
         if rank < num_vars:
             raise ValueError(
                 "The design matrix is not full rank, so the model cannot be "
-                "fitted. Please remove one or more variables from the design."
+                "fitted. Please remove the design variables that are linear "
+                "combinations of others."
             )

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -463,6 +463,9 @@ def irls_solver(
         y = np.log(counts / size_factors + 0.1)
         beta_init = solve(R, Q.T @ y)
         beta = beta_init
+    else:  # Initialise intercept with log base mean
+        beta = np.zeros(num_vars)
+        beta[0] = np.log(counts / size_factors).mean()
 
     dev = 1000.0
     dev_ratio = 1.0

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -116,7 +116,7 @@ def test_nan_factors():
 
 
 def test_one_factor():
-    """Test that a ValueError is thrown when the design factor takes only one value ."""
+    """Test that a ValueError is thrown when the design factor takes only one value."""
     counts_df = pd.DataFrame(
         {"gene1": [0, 1], "gene2": [4, 12]}, index=["sample1", "sample2"]
     )
@@ -124,6 +124,22 @@ def test_one_factor():
 
     with pytest.raises(ValueError):
         DeseqDataSet(counts=counts_df, clinical=clinical_df, design_factors="condition")
+
+
+def test_rank_deficient_design():
+    """Test that a ValueError is thrown when the design matrix does not have full column
+    rank."""
+    counts_df = pd.DataFrame(
+        {"gene1": [0, 1], "gene2": [4, 12]}, index=["sample1", "sample2"]
+    )
+    clinical_df = pd.DataFrame(
+        {"condition": [0, 1], "batch": ["A", "B"]}, index=["sample1", "sample2"]
+    )
+
+    with pytest.raises(ValueError):
+        DeseqDataSet(
+            counts=counts_df, clinical=clinical_df, design_factors=["condition", "batch"]
+        )
 
 
 def test_reference_level():


### PR DESCRIPTION
#### Reference Issue or PRs
Fixes #132

#### What does your PR implement? Be specific.

* Initializes `beta` with log mean (normalized) counts when the design is not a full rank matrix.

This as such is not enough, because (as currently defined) the model cannot be fitted if the design matrix does not have full column rank. Hence, similarly to the [DESeq2](https://github.com/mikelove/DESeq2/blob/2c3c14cbfa09300e503e08302c60ddf112beacfd/R/AllClasses.R#L295) R package, this PR:

* Checks that the design matrix has full column rank at `DeseqDataSet` initialisation,
* Implements a test to check that a `ValueError` is thrown when the design matrix has deficient column rank.
