### PR TITLE
cron scheduler: CI runs every week day at 3:30 UTC

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - '**'
   pull_request:
+  schedule:
+    # Run every week day at 3h30 UTC
+    - cron: '30 3 * * 1,2,3,4,5'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://pydeseq2.readthedocs.io/en/latest/usage/contributing.html
Make sure that you have added unit tests if applicable.
-->

#### Reference Issue or PRs
<!--
If this PR is related to an existing issue or PR please reference it, eg:
Fixes #1234.
You can use github keywords as described:
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does your PR implement? Be specific.

This PR implements a nightly CI run on every week day. Currently, the CI runs only when pull requests are submitted, which is infrequent. This prevents us from catching bugs due to version bumps early. These nightly tests will help developers catch them as soon as they arise.
