### PR TITLE
MAINT turn rank deficiency exception to warning

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -1041,8 +1041,10 @@ class DeseqDataSet(ad.AnnData):
         num_vars = self.obsm["design_matrix"].shape[1]
 
         if rank < num_vars:
-            raise ValueError(
+            warnings.warn(
                 "The design matrix is not full rank, so the model cannot be "
                 "fitted. Please remove the design variables that are linear "
-                "combinations of others."
+                "combinations of others.",
+                UserWarning,
+                stacklevel=2,
             )

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -1043,8 +1043,9 @@ class DeseqDataSet(ad.AnnData):
         if rank < num_vars:
             warnings.warn(
                 "The design matrix is not full rank, so the model cannot be "
-                "fitted. Please remove the design variables that are linear "
-                "combinations of others.",
+                "fitted, but some operations like design-free VST remain possible. "
+                "To perform differential expression analysis, please remove the design "
+                "variables that are linear combinations of others.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -136,7 +136,7 @@ def test_rank_deficient_design():
         {"condition": [0, 1], "batch": ["A", "B"]}, index=["sample1", "sample2"]
     )
 
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         DeseqDataSet(
             counts=counts_df, clinical=clinical_df, design_factors=["condition", "batch"]
         )


### PR DESCRIPTION
#### Reference Issue or PRs
Fixes #136 


#### What does your PR implement? Be specific.
Throw a `UserWarning` instead of a `ValueError` when a `DeseqDataSet` is initialized with a rank-deficient design matrix.
This allows users to run design-free VST without providing a full rank design (as described in #136).
