### PR TITLE
BUG check that `save_path` is not `None` before saving in `plot_dispersions`

### DIFF
--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -1324,5 +1324,6 @@ def make_scatter(
     plt.xlabel("mean of normalized counts")
     plt.ylabel("dispersion")
     plt.tight_layout()
-    plt.savefig(save_path, bbox_inches="tight")
+    if save_path is not None:
+        plt.savefig(save_path, bbox_inches="tight")
     plt.show()


### PR DESCRIPTION
#### What does your PR implement? Be specific.

Fixes a bug when `save_path` is not `None` in `plot_dispersions`.