### PR TITLE
BUG add ref_level argument to sub_dds when refitting cooks outliers

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -225,6 +225,7 @@ class DeseqDataSet(ad.AnnData):
         self.min_disp = min_disp
         self.max_disp = np.maximum(max_disp, self.n_obs)
         self.refit_cooks = refit_cooks
+        self.ref_level = ref_level
         self.min_replicates = min_replicates
         self.beta_tol = beta_tol
         self.n_processes = get_num_processes(n_cpus)

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -897,6 +897,7 @@ class DeseqDataSet(ad.AnnData):
             ),
             clinical=self.obs,
             design_factors=self.design_factors,
+            ref_level=self.ref_level,
             min_mu=self.min_mu,
             min_disp=self.min_disp,
             max_disp=self.max_disp,


### PR DESCRIPTION
#### What does your PR implement? Be specific.

The `ref_level` argument is missing from `sub_dds` in `_refit_without_outliers`. This can result in LFCs having the wrong sign for genes whose parameters are refitted.