### PR TITLE
add plotMA() functionality

### DIFF
--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -420,7 +420,7 @@ class DeseqStats:
 
         # Raise an error if results_df are missing
         if not self.hasattr("results_df"):
-            raise KeyError(
+            raise AttributeError(
                 "Trying to make an MA plot but p-values were not computed yet. "
                 "Please run the summary() method first."
             )

--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -16,6 +16,7 @@ from statsmodels.stats.multitest import multipletests  # type: ignore
 
 from pydeseq2.dds import DeseqDataSet
 from pydeseq2.utils import get_num_processes
+from pydeseq2.utils import make_MA_plot
 from pydeseq2.utils import nbinomGLM
 from pydeseq2.utils import wald_test
 
@@ -394,6 +395,43 @@ class DeseqStats:
             )
 
             display(self.results_df)
+
+    def plot_MA(self, log: bool = True, save_path: Optional[str] = None, **kwargs):
+        """
+        Create an log ratio (M)-average (A) plot using matplotlib.
+
+        Useful for looking at log fold-change versus mean expression
+        between two groups/samples/etc.
+        Uses matplotlib to emulate make_MA() function in DESeq2 in R.
+
+        Parameters
+        ----------
+
+        log : bool
+            Whether or not to log scale x and y axes (``default=True``).
+
+        save_path : str or None
+            The path where to save the plot. If left None, the plot won't be saved
+            (``default=None``).
+
+        **kwargs
+            Matplotlib keyword arguments for the scatter plot.
+        """
+
+        # Raise an error if results_df are missing
+        if not self.hasattr("results_df"):
+            raise KeyError(
+                "Trying to make an MA plot but p-values were not computed yet. "
+                "Please run the summary() method first."
+            )
+
+        make_MA_plot(
+            self.results_df,
+            padj_thresh=self.alpha,
+            log=log,
+            save_path=save_path,
+            **kwargs,
+        )
 
     def _independent_filtering(self) -> None:
         """Compute adjusted p-values using independent filtering.

--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -419,7 +419,7 @@ class DeseqStats:
         """
 
         # Raise an error if results_df are missing
-        if not self.hasattr("results_df"):
+        if not hasattr(self, "results_df"):
             raise AttributeError(
                 "Trying to make an MA plot but p-values were not computed yet. "
                 "Please run the summary() method first."

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -1337,9 +1337,7 @@ def plotMA(
     **kwargs,
 ) -> None:
     """
-    Create an MA plot using matplotlib.
-    MA plots display a log ratio (M) vs an average (A)
-    to visualize the differences between two groups in bulk RNAseq.
+    Create an log ratio (M)-average (A) plot using matplotlib.
 
     Parameters
     ----------
@@ -1347,7 +1345,7 @@ def plotMA(
         Resultant dataframe after running DeseqStats() and .summary().
 
     padj_thresh : float
-        P-value threshold to subset scatterplot colors on
+        P-value threshold to subset scatterplot colors on.
 
     log : bool
         Whether or not to log scale x and y axes (``default=True``).

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -1329,7 +1329,7 @@ def make_scatter(
     plt.show()
 
 
-def plotMA(
+def make_MA_plot(
     results_df: pd.DataFrame,
     padj_thresh: float = 0.05,
     log: bool = True,
@@ -1341,7 +1341,7 @@ def plotMA(
 
     Useful for looking at log fold-change versus mean expression
     between two groups/samples/etc.
-    Uses matplotlib to emulate plotMA() function in DESeq2 in R.
+    Uses matplotlib to emulate make_MA() function in DESeq2 in R.
 
     Parameters
     ----------
@@ -1366,9 +1366,7 @@ def plotMA(
     # these rows include those that have a low mean normalized count,
     # with extreme count outliers, or those in which all samples have zero counts
 
-    results_df.loc[results_df["padj"] <= padj_thresh, "color"] = "darkred"
-    results_df.loc[results_df["padj"] > padj_thresh, "color"] = "gray"
-    results_df.loc[results_df["padj"].isna(), "color"] = "gray"
+    colors = results_df["padj"].apply(lambda x: "darkred" if x < padj_thresh else "gray")
 
     fig, ax = plt.subplots(dpi=600)
 
@@ -1379,7 +1377,7 @@ def plotMA(
     plt.scatter(
         x=results_df["baseMean"],
         y=results_df["log2FoldChange"],
-        c=list(results_df["color"].values),
+        c=colors,
         **kwargs,
     )
 

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -1290,7 +1290,7 @@ def make_scatter(
         (``default=None``).
 
     **kwargs
-        Keyword arguments for the scatter plot.
+        Matplotlib keyword arguments for the scatter plot.
     """
 
     # Adding more colors if plotting more than 3 traces
@@ -1359,12 +1359,8 @@ def make_MA_plot(
         (``default=None``).
 
     **kwargs
-        Keyword arguments for the scatter plot.
+        Matplotlib keyword arguments for the scatter plot.
     """
-    # add a column for color -- red dots are significant/under user-specified threshold
-    # rows that return NaN for padj are set to gray
-    # these rows include those that have a low mean normalized count,
-    # with extreme count outliers, or those in which all samples have zero counts
 
     colors = results_df["padj"].apply(lambda x: "darkred" if x < padj_thresh else "gray")
 
@@ -1387,7 +1383,7 @@ def make_MA_plot(
         plt.xscale("log")
 
     plt.xlabel("mean of normalized counts")
-    plt.ylabel("log fold change")
+    plt.ylabel("log2 fold change")
 
     plt.axhline(0, color="red", alpha=0.5, linestyle="--", zorder=3)
     plt.tight_layout()

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -1337,15 +1337,17 @@ def plotMA(
     **kwargs,
 ) -> None:
     """
-    Creates an MA plot using matplotlib.
+    Create an MA plot using matplotlib.
     MA plots display a log ratio (M) vs an average (A)
-    to visualize the differences between two groups in bulk RNAseq
-
+    to visualize the differences between two groups in bulk RNAseq.
 
     Parameters
     ----------
     results_df : pd.DataFrame
-        the resultant dataframe after running DeseqStats() and .summary().
+        Resultant dataframe after running DeseqStats() and .summary().
+
+    padj_thresh : float
+        P-value threshold to subset scatterplot colors on
 
     log : bool
         Whether or not to log scale x and y axes (``default=True``).
@@ -1357,7 +1359,6 @@ def plotMA(
     **kwargs
         Keyword arguments for the scatter plot.
     """
-
     # add a column for color -- red dots are significant/under user-specified threshold
     # rows that return NaN for padj are set to gray
     # these rows include those that have a low mean normalized count,

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -1339,6 +1339,10 @@ def plotMA(
     """
     Create an log ratio (M)-average (A) plot using matplotlib.
 
+    Useful for looking at log fold-change versus mean expression
+    between two groups/samples/etc.
+    Uses matplotlib to emulate plotMA() function in DESeq2 in R.
+
     Parameters
     ----------
     results_df : pd.DataFrame

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -412,3 +412,36 @@ def test_zero_inflated():
     dds = DeseqDataSet(counts=counts_df, clinical=clinical_df)
     with pytest.warns(RuntimeWarning):
         dds.deseq2()
+
+
+def test_plot_MA():
+    """
+    Test that a KeyError is thrown when attempting to run plot_MA without running the
+    statistical analysis first.
+    """
+
+    counts_df = load_example_data(
+        modality="raw_counts",
+        dataset="synthetic",
+        debug=False,
+    )
+
+    clinical_df = load_example_data(
+        modality="clinical",
+        dataset="synthetic",
+        debug=False,
+    )
+
+    dds = DeseqDataSet(counts=counts_df, clinical=clinical_df)
+    dds.deseq2()
+
+    # Initialize a DeseqStats object without runnning the analysis
+    res = DeseqStats(dds)
+
+    with pytest.raises(AttributeError):
+        res.plot_MA()
+
+    # Run the analysis
+    res.summary()
+    # Now this shouldn't throw an error
+    res.plot_MA()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://pydeseq2.readthedocs.io/en/latest/usage/contributing.html
Make sure that you have added unit tests if applicable.
-->

#### Reference Issue or PRs
<!--
If this PR is related to an existing issue or PR please reference it, eg:
Fixes #1234.
You can use github keywords as described:
https://github.com/blog/1506-closing-issues-via-pull-requests
-->
There is no existing issue that I saw that is requesting this functionality.

#### What does your PR implement? Be specific.
This PR uses matplotlib to implement a `plotMA()` function. 
The MA plot shows the mean of the normalized counts versus the log2 fold changes for all genes tested. Genes that are significantly differentially expressed (based on some user-specified threshold) are colored red; the non-significant genes are colored grey. This plot can be helpful to look at LFC shrinkage effects. 

This functionality tries to copy the version of `plotMA()` in R. Example: 
![image](https://github.com/owkin/PyDESeq2/assets/22733781/b27c521a-9eca-4f69-8893-84533031a6d4)


A couple of considerations I wanted to flag:
1. Rows that return NaN in padj are colored grey and ultimately ignored (let me know if you'd like me to change this behavior, I think in R they are also ignored?)
2. I modify the results_df to add a new column, color. This may not be preferable, and I'd be grateful for input to clean this up.
3. There is some overlap between this and `make_scatter()` -- if it's helpful, I could potentially generalize `make_scatter()` to work with `plot_dispersions()` and `MAplot()`