### PR TITLE
DOC Degrees of freedom corner case

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -557,6 +557,9 @@ class DeseqDataSet(ad.AnnData):
         """Fit dispersion variance priors and standard deviation of log-residuals.
 
         The computation is based on genes whose dispersions are above 100 * min_disp.
+
+        NB: when the design matrix has fewer than 3 degrees of freedom, the
+        estimate of log dispersions is likely to be imprecise.
         """
 
         # Check that the dispersion trend curve was fitted. If not, fit it.

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -83,7 +83,7 @@ class DeseqDataSet(ad.AnnData):
 
     max_disp : float
         Upper threshold for dispersion parameters.
-        NB: The threshold that is actually enforced is max(max_disp, len(counts)).
+        Note: The threshold that is actually enforced is max(max_disp, len(counts)).
         (default: ``10``).
 
     refit_cooks : bool
@@ -558,7 +558,7 @@ class DeseqDataSet(ad.AnnData):
 
         The computation is based on genes whose dispersions are above 100 * min_disp.
 
-        NB: when the design matrix has fewer than 3 degrees of freedom, the
+        Note: when the design matrix has fewer than 3 degrees of freedom, the
         estimate of log dispersions is likely to be imprecise.
         """
 

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -569,6 +569,16 @@ class DeseqDataSet(ad.AnnData):
         num_samples = self.n_obs
         num_vars = self.obsm["design_matrix"].shape[-1]
 
+        # Check the degrees of freedom
+        if (num_samples - num_vars) <= 3:
+            warnings.warn(
+                "As the residual degrees of freedom is less than 3, the distribution "
+                "of log dispersions is especially asymmetric and likely to be poorly "
+                "estimated by the MAD.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         # Fit dispersions to the curve, and compute log residuals
         disp_residuals = np.log(
             self[:, self.non_zero_genes].varm["genewise_dispersions"]
@@ -583,6 +593,7 @@ class DeseqDataSet(ad.AnnData):
         self.uns["_squared_logres"] = (
             mean_absolute_deviation(disp_residuals[above_min_disp]) ** 2
         )
+
         self.uns["prior_disp_var"] = np.maximum(
             self.uns["_squared_logres"] - polygamma(1, (num_samples - num_vars) / 2),
             0.25,

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -41,8 +41,6 @@ warnings.simplefilter("ignore", DomainWarning)
 # Ignore AnnData's FutureWarning about implicit data conversion.
 warnings.simplefilter("ignore", FutureWarning)
 
-# TODO: implement a quiet (non-verbose) mode ?
-
 
 class DeseqDataSet(ad.AnnData):
     r"""A class to implement dispersion and log fold-change (LFC) estimation.

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -317,14 +317,16 @@ def test_few_samples():
     # Introduce an outlier
     counts_df.iloc[0, 0] = 1000
 
-    # Run analysis. Should not throw an error.
+    # Run analysis. Should not throw degrees of freedom warning.
     dds = DeseqDataSet(
         counts=counts_df,
         clinical=clinical_df,
         refit_cooks=True,
         design_factors="condition",
     )
-    dds.deseq2()
+
+    with pytest.warns(UserWarning):
+        dds.deseq2()
 
     res = DeseqStats(dds)
     res.summary()


### PR DESCRIPTION
#### What does your PR implement? Be specific.

As pointed out by @mikelove, in the corner case where the design matrix has fewer than 3 degrees of freedom, the distribution of log dispersions is poorly estimated by the MAD, as in `fit_dispersion_prior` (cf the [DESeq2](https://github.com/mikelove/DESeq2/blob/24099effd42f31b96bf7c867ea03d7300a6368bc/R/core.R#L631) implementation of `estimateDispersionsPriorVar`).

This is a relatively minor issue that should be addressed in the future. Meanwhile, this PR:

- updates the docstring of `fit_dispersion_prior` to reflect this issue,
- raises a warning when this corner case arises.  