### PR TITLE
MAINT reduce the number of arguments in ``_fit_rough_dispersions``

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -826,12 +826,11 @@ class DeseqDataSet(ad.AnnData):
         """
 
         # Check that size_factors are available. If not, compute them.
-        if "size_factors" not in self.obsm:
+        if "normed_counts" not in self.layers:
             self.fit_size_factors()
 
         rde = fit_rough_dispersions(
-            self.X,
-            self.obsm["size_factors"],
+            self.layers["normed_counts"],
             self.obsm["design_matrix"],
         )
         mde = fit_moments_dispersions(self.X, self.obsm["size_factors"])
@@ -1053,7 +1052,9 @@ class DeseqDataSet(ad.AnnData):
 
         """
 
+        # Initialize size factors and normed counts fields
         self.obsm["size_factors"] = np.ones(self.n_obs)
+        self.layers["normed_counts"] = self.X
 
         # Reduce the design matrix to an intercept and reconstruct at the end
         self.obsm["design_matrix_buffer"] = self.obsm["design_matrix"].copy()

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -467,7 +467,7 @@ class DeseqDataSet(ad.AnnData):
                         counts=self.X[:, i],
                         size_factors=self.obsm["size_factors"],
                         design_matrix=design_matrix,
-                        disp=self.varm["_rough_dispersions"][i],
+                        disp=self.varm["_MoM_dispersions"][i],
                         min_mu=self.min_mu,
                         beta_tol=self.beta_tol,
                     )
@@ -493,7 +493,7 @@ class DeseqDataSet(ad.AnnData):
                     counts=self.X[:, i],
                     design_matrix=design_matrix,
                     mu=self.layers["_mu_hat"][:, i],
-                    alpha_hat=self.varm["_rough_dispersions"][i],
+                    alpha_hat=self.varm["_MoM_dispersions"][i],
                     min_disp=self.min_disp,
                     max_disp=self.max_disp,
                 )
@@ -838,8 +838,8 @@ class DeseqDataSet(ad.AnnData):
         )
         alpha_hat = np.minimum(rde, mde)
 
-        self.varm["_rough_dispersions"] = np.full(self.n_vars, np.NaN)
-        self.varm["_rough_dispersions"][self.varm["non_zero"]] = np.clip(
+        self.varm["_MoM_dispersions"] = np.full(self.n_vars, np.NaN)
+        self.varm["_MoM_dispersions"][self.varm["non_zero"]] = np.clip(
             alpha_hat, self.min_disp, self.max_disp
         )
 

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -833,7 +833,9 @@ class DeseqDataSet(ad.AnnData):
             self.layers["normed_counts"],
             self.obsm["design_matrix"],
         )
-        mde = fit_moments_dispersions(self.X, self.obsm["size_factors"])
+        mde = fit_moments_dispersions(
+            self.layers["normed_counts"], self.obsm["size_factors"]
+        )
         alpha_hat = np.minimum(rde, mde)
 
         self.varm["_rough_dispersions"] = np.full(self.n_vars, np.NaN)

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -949,7 +949,7 @@ def fit_rough_dispersions(
 
     Parameters
     ----------
-    normed_counts : ndarry
+    normed_counts : ndarray
         Array of deseq2-normalized read counts. Rows: samples, columns: genes.
 
     design_matrix : pandas.DataFrame

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -976,7 +976,9 @@ def fit_rough_dispersions(
     return np.maximum(alpha_rde, 0)
 
 
-def fit_moments_dispersions(counts: np.ndarray, size_factors: np.ndarray) -> np.ndarray:
+def fit_moments_dispersions(
+    normed_counts: np.ndarray, size_factors: np.ndarray
+) -> np.ndarray:
     """Dispersion estimates based on moments, as per the R code.
 
     Used as initial estimates in :meth:`DeseqDataSet.fit_genewise_dispersions()
@@ -984,8 +986,8 @@ def fit_moments_dispersions(counts: np.ndarray, size_factors: np.ndarray) -> np.
 
     Parameters
     ----------
-    counts : ndarray
-        Raw counts. One column per gene, one row per sample.
+    normed_counts : ndarray
+        Array of deseq2-normalized read counts. Rows: samples, columns: genes.
 
     size_factors : ndarray
         DESeq2 normalization factors.
@@ -996,7 +998,6 @@ def fit_moments_dispersions(counts: np.ndarray, size_factors: np.ndarray) -> np.
         Estimated dispersion parameter for each gene.
     """
 
-    normed_counts = counts / size_factors[:, None]
     # Exclude genes with all zeroes
     normed_counts = normed_counts[:, ~(normed_counts == 0).all(axis=0)]
     # mean inverse size factor

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -940,7 +940,7 @@ def wald_test(
 
 
 def fit_rough_dispersions(
-    counts: np.ndarray, size_factors: np.ndarray, design_matrix: pd.DataFrame
+    normed_counts: np.ndarray, design_matrix: pd.DataFrame
 ) -> np.ndarray:
     """ "Rough dispersion" estimates from linear model, as per the R code.
 
@@ -949,11 +949,8 @@ def fit_rough_dispersions(
 
     Parameters
     ----------
-    counts : ndarray
-        Raw counts. One column per gene, one row per sample.
-
-    size_factors : ndarray
-        DESeq2 normalization factors.
+    normed_counts : ndarry
+        Array of deseq2-normalized read counts. Rows: samples, columns: genes.
 
     design_matrix : pandas.DataFrame
         A DataFrame with experiment design information (to split cohorts).
@@ -966,9 +963,6 @@ def fit_rough_dispersions(
     """
 
     num_samples, num_vars = design_matrix.shape
-
-    normed_counts = counts / size_factors[:, None]
-
     # Exclude genes with all zeroes
     normed_counts = normed_counts[:, ~(normed_counts == 0).all(axis=0)]
 


### PR DESCRIPTION
#### What does your PR implement? Be specific.

This PR is a minor refactoring of `DeseqDataSet._fit_rough_dispersions()`.

 Currently, this method takes both `counts` and `size_factors` as arguments, only to compute normalized factors as `counts / size_factors[:, None]`.

We now provide `normed_counts` directly, which are already stored in `self.layers["normed_counts"]` when `_fit_rough_dispersions()` is called in the pydeseq2 pipeline.

Likewise, we provide `normed_counts` instead of `counts` in `_fit_moments_dispersions()` to avoid performing the division again.