### PR TITLE
FEAT: Implement Likelihood-Ratio test

### DIFF
--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -146,6 +146,7 @@ class DeseqStats:
     def __init__(
         self,
         dds: DeseqDataSet,
+        test: Literal["Wald", "LRT"] = "Wald",
         contrast: Optional[List[str]] = None,
         alpha: float = 0.05,
         cooks_filter: bool = True,
@@ -167,6 +168,7 @@ class DeseqStats:
         self.dds = dds
 
         self.alpha = alpha
+        self.test = test
         self.cooks_filter = cooks_filter
         self.independent_filter = independent_filter
         self.base_mean = self.dds.varm["_normed_means"].copy()


### PR DESCRIPTION
This PR implements the Likelihood-Ratio test to assess the statistical significance of log fold changes.

It proceeds as follows:

- [ ] Add the LRT logic comparing a full and reduced model where the reduced model removes a single LFC term (df = 1)
- [ ] LRT supporting custom formulas as in the original `DeSeq2` implementation.

Closes #176 