### PR TITLE
Drop iPython dependency and simple print instead

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,3 +13,4 @@ sphinx_gallery==0.11.1
 sphinx_autodoc_typehints
 sphinxcontrib-bibtex==2.5.0
 gitpython>=3.1.27
+ipython

--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -8,7 +8,6 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 import statsmodels.api as sm  # type: ignore
-from IPython.display import display  # type: ignore
 from joblib import Parallel  # type: ignore
 from joblib import delayed  # type: ignore
 from joblib import parallel_backend  # type: ignore
@@ -282,7 +281,7 @@ class DeseqStats:
                 f"Log2 fold change & Wald test p-value: "
                 f"{self.contrast[0]} {self.contrast[1]} vs {self.contrast[2]}"
             )
-        display(self.results_df)
+        print(self.results_df)
 
     def run_wald_test(self) -> None:
         """Perform a Wald test.
@@ -496,7 +495,7 @@ class DeseqStats:
                     f"{split_coeff[0]} {split_coeff[1]} vs {split_coeff[3]}"
                 )
 
-            display(self.results_df)
+            print(self.results_df)
 
     def plot_MA(self, log: bool = True, save_path: Optional[str] = None, **kwargs):
         """

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         "anndata>=0.8.0",
-        "ipython",
         "numpy>=1.23.0",
         "pandas>=1.4.0",
         "scikit-learn>=1.1.0",


### PR DESCRIPTION
IPython is a heavy dependency (especially for non-essential functionality), and it would be appreciated to replace this with something simpler. Thanks!
