### PR TITLE
Remove precommit from workflow

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -39,11 +39,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pre-commit
           pip install -e ."[dev]"
           pip install -r docs/requirements.txt
-      - name: pre-commit
-        run: pre-commit run --all-files --show-diff-on-failure
       - name: Test with pytest
         run: |
           coverage run -m pytest


### PR DESCRIPTION
With pre-commit ci, this step is no longer necessary and blocks testing the actual code