### PR TITLE
BUG set normed_counts in sub_dds before recomputing genewise dispersions when refitting

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -976,6 +976,9 @@ class DeseqDataSet(ad.AnnData):
 
         # Use the same size factors
         sub_dds.obsm["size_factors"] = self.counts_to_refit.obsm["size_factors"]
+        sub_dds.layers["normed_counts"] = (
+            sub_dds.X / sub_dds.obsm["size_factors"][:, None]
+        )
 
         # Estimate gene-wise dispersions.
         sub_dds.fit_genewise_dispersions()
@@ -983,9 +986,7 @@ class DeseqDataSet(ad.AnnData):
         # Compute trend dispersions.
         # Note: the trend curve is not refitted.
         sub_dds.uns["trend_coeffs"] = self.uns["trend_coeffs"]
-        sub_dds.varm["_normed_means"] = (
-            self.counts_to_refit.X / self.counts_to_refit.obsm["size_factors"][:, None]
-        ).mean(0)
+        sub_dds.varm["_normed_means"] = sub_dds.layers["normed_counts"].mean(0)
         sub_dds.varm["fitted_dispersions"] = dispersion_trend(
             sub_dds.varm["_normed_means"],
             sub_dds.uns["trend_coeffs"],


### PR DESCRIPTION
#### What does your PR implement? Be specific.

In `dds._refit_without_outliers`, the `obsm["size_factors"]` of `sub_dds` should be the same as the original object when computing genewise dispersions.

However, since version 0.4.1, the `_fit_MoM_dispersions` method (called by `fit_genewise_dispersions`) first checks if a `normed_counts` layer exists, and if not, runs `fit_size_factors`.

This caused size factors to be overwritten in `dds._refit_without_outliers`.

To fix this, this PR sets the `normed_counts` layer in `sub_dds` before computing genewise dispersions.