### PR TITLE
TST: ignore the DeprecationWarning from pandas `is_categorical_dtype`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ convention = "numpy"
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
-    "ignore::DeprecationWarning:patsy[.*]",
+    #"ignore::DeprecationWarning:patsy[.*]", # due to patsy being a dependency of statsmodels and calling pandas.
+    "ignore::DeprecationWarning:pandas.core.dtypes.common.is_categorical_dtype",
     "ignore::statsmodels.tools.sm_exceptions.DomainWarning", # due to fitting the dipersion curve with the identity link
     "ignore::FutureWarning", # Ignore AnnData FutureWarning about implicit conversion
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ convention = "numpy"
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
-    #"ignore::DeprecationWarning:patsy[.*]", # due to patsy being a dependency of statsmodels and calling pandas.
-    "ignore::DeprecationWarning:pandas.core.dtypes.common.is_categorical_dtype",
+    "ignore::DeprecationWarning:patsy[.*]", # due to patsy being a dependency of statsmodels and
+    # calling pandas.core.dtypes.common.is_categorical_dtype.
     "ignore::statsmodels.tools.sm_exceptions.DomainWarning", # due to fitting the dipersion curve with the identity link
     "ignore::FutureWarning", # Ignore AnnData FutureWarning about implicit conversion
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ convention = "numpy"
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
-    "ignore::DeprecationWarning:statsmodels[.*]",
+    "ignore::DeprecationWarning:patsy[.*]",
     "ignore::statsmodels.tools.sm_exceptions.DomainWarning", # due to fitting the dipersion curve with the identity link
     "ignore::FutureWarning", # Ignore AnnData FutureWarning about implicit conversion
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,6 @@ convention = "numpy"
 filterwarnings = [
     "error",
     "ignore::statsmodels.tools.sm_exceptions.DomainWarning", # due to fitting the dipersion curve with the identity link
-    "ignore::FutureWarning" # Ignore AnnData FutureWarning about implicit conversion
+    "ignore::FutureWarning", # Ignore AnnData FutureWarning about implicit conversion
+    "ignore::DeprecationWarning:statsmodels[.*]"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ convention = "numpy"
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
+    "ignore::DeprecationWarning:statsmodels[.*]",
     "ignore::statsmodels.tools.sm_exceptions.DomainWarning", # due to fitting the dipersion curve with the identity link
     "ignore::FutureWarning", # Ignore AnnData FutureWarning about implicit conversion
-    "ignore::DeprecationWarning:statsmodels[.*]"
 ]


### PR DESCRIPTION
#### Reference Issue or PRs

Related to github actions test recently failing.
s
#### What does your PR implement? Be specific.

The test suite failed due to a `DeprecationWarning` raised by `pandas.core.dtypes.common.is_categorical_dtype`. This function is imported by `patsy`, which as dependency of `pandas`.

This PR temporarily fixes this issue by ignoring `DeprecationWarning`s from `patsy`.

Once this issue is fixed in `patsy` or `statsmodels`, this filter should be removed.