### PR TITLE
Add back n_cpus argument in DeseqDataSet

### DIFF
--- a/examples/plot_minimal_pydeseq2_pipeline.py
+++ b/examples/plot_minimal_pydeseq2_pipeline.py
@@ -137,6 +137,7 @@ dds = DeseqDataSet(
     design_factors="condition",
     refit_cooks=True,
     inference=inference,
+    # n_cpus=8, # n_cpus can be specified here or in the inference object
 )
 
 # %%

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -282,11 +282,11 @@ class DeseqDataSet(ad.AnnData):
             n_cpus = get_num_processes(n_cpus)
             if inference:
                 try:
-                    inference.n_cpus = n_cpus
+                    inference.n_cpus = n_cpus  # type: ignore[attr-defined]
                 except AttributeError:
                     warnings.warn(
                         "The provided inference object does not have an n_cpus "
-                        "attribute, cannot override `n_cpus`.",
+                        "setter, cannot override `n_cpus`.",
                         UserWarning,
                         stacklevel=2,
                     )

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -21,7 +21,6 @@ from pydeseq2.preprocessing import deseq2_norm_fit
 from pydeseq2.preprocessing import deseq2_norm_transform
 from pydeseq2.utils import build_design_matrix
 from pydeseq2.utils import dispersion_trend
-from pydeseq2.utils import get_num_processes
 from pydeseq2.utils import make_scatter
 from pydeseq2.utils import mean_absolute_deviation
 from pydeseq2.utils import n_or_more_replicates
@@ -278,18 +277,16 @@ class DeseqDataSet(ad.AnnData):
         self.logmeans = None
         self.filtered_genes = None
 
-        if n_cpus:
-            n_cpus = get_num_processes(n_cpus)
-            if inference:
-                try:
-                    inference.n_cpus = n_cpus  # type: ignore[attr-defined]
-                except AttributeError:
-                    warnings.warn(
-                        "The provided inference object does not have an n_cpus "
-                        "setter, cannot override `n_cpus`.",
-                        UserWarning,
-                        stacklevel=2,
-                    )
+        if inference:
+            if hasattr(inference, "n_cpus"):
+                inference.n_cpus = n_cpus
+            else:
+                warnings.warn(
+                    "The provided inference object does not have an n_cpus "
+                    "attribute, cannot override `n_cpus`.",
+                    UserWarning,
+                    stacklevel=2,
+                )
         # Initialize the inference object.
         self.inference = inference or DefaultInference(n_cpus=n_cpus)
 

--- a/pydeseq2/default_inference.py
+++ b/pydeseq2/default_inference.py
@@ -54,6 +54,14 @@ class DefaultInference(inference.Inference):
         self._n_processes = utils.get_num_processes(n_cpus)
         self._backend = backend
 
+    @property
+    def n_cpus(self) -> int:  # noqa: D102
+        return self._n_processes
+
+    @n_cpus.setter
+    def n_cpus(self, n_cpus: int) -> None:
+        self._n_processes = n_cpus
+
     def lin_reg_mu(  # noqa: D102
         self,
         counts: np.ndarray,
@@ -64,7 +72,7 @@ class DefaultInference(inference.Inference):
         with parallel_backend(self._backend, inner_max_num_threads=1):
             mu_hat_ = np.array(
                 Parallel(
-                    n_jobs=self._n_processes,
+                    n_jobs=self.n_cpus,
                     verbose=self._joblib_verbosity,
                     batch_size=self._batch_size,
                 )(
@@ -94,7 +102,7 @@ class DefaultInference(inference.Inference):
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         with parallel_backend(self._backend, inner_max_num_threads=1):
             res = Parallel(
-                n_jobs=self._n_processes,
+                n_jobs=self.n_cpus,
                 verbose=self._joblib_verbosity,
                 batch_size=self._batch_size,
             )(
@@ -137,7 +145,7 @@ class DefaultInference(inference.Inference):
     ) -> Tuple[np.ndarray, np.ndarray]:
         with parallel_backend(self._backend, inner_max_num_threads=1):
             res = Parallel(
-                n_jobs=self._n_processes,
+                n_jobs=self.n_cpus,
                 verbose=self._joblib_verbosity,
                 batch_size=self._batch_size,
             )(
@@ -175,7 +183,7 @@ class DefaultInference(inference.Inference):
         num_genes = mu.shape[1]
         with parallel_backend(self._backend, inner_max_num_threads=1):
             res = Parallel(
-                n_jobs=self._n_processes,
+                n_jobs=self.n_cpus,
                 verbose=self._joblib_verbosity,
                 batch_size=self._batch_size,
             )(
@@ -225,7 +233,7 @@ class DefaultInference(inference.Inference):
         with parallel_backend(self._backend, inner_max_num_threads=1):
             num_genes = counts.shape[1]
             res = Parallel(
-                n_jobs=self._n_processes,
+                n_jobs=self.n_cpus,
                 verbose=self._joblib_verbosity,
                 batch_size=self._batch_size,
             )(

--- a/pydeseq2/default_inference.py
+++ b/pydeseq2/default_inference.py
@@ -51,16 +51,16 @@ class DefaultInference(inference.Inference):
     ):
         self._joblib_verbosity = joblib_verbosity
         self._batch_size = batch_size
-        self._n_processes = utils.get_num_processes(n_cpus)
+        self._n_cpus = utils.get_num_processes(n_cpus)
         self._backend = backend
 
     @property
     def n_cpus(self) -> int:  # noqa: D102
-        return self._n_processes
+        return self._n_cpus
 
     @n_cpus.setter
     def n_cpus(self, n_cpus: int) -> None:
-        self._n_processes = n_cpus
+        self._n_cpus = utils.get_num_processes(n_cpus)
 
     def lin_reg_mu(  # noqa: D102
         self,

--- a/pydeseq2/inference.py
+++ b/pydeseq2/inference.py
@@ -11,16 +11,6 @@ import pandas as pd
 class Inference(ABC):
     """Abstract class with DESeq2-related inference methods."""
 
-    @property
-    @abstractmethod
-    def n_cpus(self):
-        """Return the number of cpus to use during inference."""
-
-    @n_cpus.setter
-    @abstractmethod
-    def n_cpus(self, val):
-        """Set the number of cpus to use during inference."""
-
     @abstractmethod
     def lin_reg_mu(
         self,

--- a/pydeseq2/inference.py
+++ b/pydeseq2/inference.py
@@ -11,6 +11,16 @@ import pandas as pd
 class Inference(ABC):
     """Abstract class with DESeq2-related inference methods."""
 
+    @property
+    @abstractmethod
+    def n_cpus(self):
+        """Return the number of cpus to use during inference."""
+
+    @n_cpus.setter
+    @abstractmethod
+    def n_cpus(self, val):
+        """Set the number of cpus to use during inference."""
+
     @abstractmethod
     def lin_reg_mu(
         self,


### PR DESCRIPTION
#### Reference Issue or PRs
Fixes #214


#### What does your PR implement? Be specific.
Adding back n_cpus as an optional keyword argument in DeseqDataSet, and adding `n_cpus` as an abstract property in the Inference class, in order to override the cpus of the `inference` instance passed to DeseqDataSet (let me know if you prefer to not have that and just have a warning instead). 
