### PR TITLE
CI: ignore the deprecation warning about the future Pyarrow dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ filterwarnings = [
     "error",
     "ignore::DeprecationWarning:patsy[.*]", # due to patsy being a dependency of statsmodels and
     # calling pandas.core.dtypes.common.is_categorical_dtype.
+    "ignore::DeprecationWarning:pandas[.*]", # ignore Pyarrow deprecation warnings
     "ignore::statsmodels.tools.sm_exceptions.DomainWarning", # due to fitting the dipersion curve with the identity link
     "ignore::FutureWarning", # Ignore AnnData FutureWarning about implicit conversion
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ filterwarnings = [
     "error",
     "ignore::DeprecationWarning:patsy[.*]", # due to patsy being a dependency of statsmodels and
     # calling pandas.core.dtypes.common.is_categorical_dtype.
-    "ignore::DeprecationWarning:pandas[.*]", # ignore Pyarrow deprecation warnings
+    "ignore::DeprecationWarning:pandas", # ignore Pyarrow deprecation warnings
     "ignore::statsmodels.tools.sm_exceptions.DomainWarning", # due to fitting the dipersion curve with the identity link
     "ignore::FutureWarning", # Ignore AnnData FutureWarning about implicit conversion
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ filterwarnings = [
     "error",
     "ignore::DeprecationWarning:patsy[.*]", # due to patsy being a dependency of statsmodels and
     # calling pandas.core.dtypes.common.is_categorical_dtype.
-    "ignore::DeprecationWarning:pandas", # ignore Pyarrow deprecation warnings
+    "ignore::DeprecationWarning:statsmodels", # ignore Pyarrow deprecation warnings
     "ignore::statsmodels.tools.sm_exceptions.DomainWarning", # due to fitting the dipersion curve with the identity link
     "ignore::FutureWarning", # Ignore AnnData FutureWarning about implicit conversion
 ]


### PR DESCRIPTION
#### What does your PR implement? Be specific.

Ignore pandas' warning that v3.0 will require Pyarrow
