### PR TITLE
MAINT Remove statsmodels

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -18,8 +18,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: "3.8"
-          - os: ubuntu-latest
             python: "3.9"
           - os: ubuntu-latest
             python: "3.10"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ For reference, the code is being tested in a github workflow (CI) with python
 - pandas 1.4.3
 - scikit-learn 1.1.1
 - scipy 1.8.1
-- statsmodels 0.13.2
 ```
 
 Please don't hesitate to open an issue in case you encounter any issue due to possible deprecations.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,8 +7,6 @@
 
 # -- Path setup --------------------------------------------------------------
 
-import warnings
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -17,12 +15,9 @@ from datetime import date
 from pathlib import Path
 
 import git
-from statsmodels.tools.sm_exceptions import DomainWarning
 
 import pydeseq2
 
-# Ignore DomainWarning raised by statsmodels when fitting a Gamma GLM with identity link.
-warnings.simplefilter("ignore", DomainWarning)
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/source/usage/requirements.rst
+++ b/docs/source/usage/requirements.rst
@@ -8,6 +8,5 @@ For reference, the code was tested with python 3.8 and the following package ver
     - pandas==1.4.3
     - scikit-learn==1.1.1
     - scipy==1.8.1
-    - statsmodels==0.13.2
 
 Please don't hesitate to open an issue in case you encounter any problems due to possible deprecations.

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -625,12 +625,10 @@ class DeseqDataSet(ad.AnnData):
             self.uns["trend_coeffs"] = pd.Series(coeffs, index=["a0", "a1"])
 
             self.varm["fitted_dispersions"] = np.full(self.n_vars, np.NaN)
-            self.uns["disp_function"] = lambda x: dispersion_trend(
-                x, self.uns["trend_coeffs"]
+            self.uns["disp_function_type"] = "parametric"
+            self.varm["fitted_dispersions"][self.varm["non_zero"]] = self.disp_function(
+                self.varm["_normed_means"][self.varm["non_zero"]]
             )
-            self.varm["fitted_dispersions"][self.varm["non_zero"]] = self.uns[
-                "disp_function"
-            ](self.varm["_normed_means"][self.varm["non_zero"]])
 
         except RuntimeError:
             warnings.warn(
@@ -639,20 +637,27 @@ class DeseqDataSet(ad.AnnData):
                 UserWarning,
                 stacklevel=2,
             )
-            mean_disp = trim_mean(
+            self.uns["mean_disp"] = trim_mean(
                 self.varm["genewise_dispersions"][
                     self.varm["genewise_dispersions"] > 10 * self.min_disp
                 ],
                 proportiontocut=0.001,
             )
 
-            self.uns["disp_function"] = lambda x: mean_disp
-            self.varm["fitted_dispersions"] = np.full(self.n_vars, mean_disp)
+            self.uns["disp_function_type"] = "mean"
+            self.varm["fitted_dispersions"] = np.full(self.n_vars, self.uns["mean_disp"])
 
         end = time.time()
 
         if not self.quiet:
             print(f"... done in {end - start:.2f} seconds.\n", file=sys.stderr)
+
+    def disp_function(self, x):
+        """Return the dispersion trend function at x."""
+        if self.uns["disp_function_type"] == "parametric":
+            return dispersion_trend(x, self.uns["trend_coeffs"])
+        elif self.uns["disp_function_type"] == "mean":
+            return self.uns["mean_disp"]
 
     def fit_dispersion_prior(self) -> None:
         """Fit dispersion variance priors and standard deviation of log-residuals.
@@ -1021,10 +1026,14 @@ class DeseqDataSet(ad.AnnData):
 
         # Compute trend dispersions.
         # Note: the trend curve is not refitted.
-        sub_dds.uns["disp_function"] = self.uns["disp_function"]
+        sub_dds.uns["disp_function_type"] = self.uns["disp_function_type"]
+        if sub_dds.uns["disp_function_type"] == "parametric":
+            sub_dds.uns["trend_coeffs"] = self.uns["trend_coeffs"]
+        elif sub_dds.uns["disp_function_type"] == "mean":
+            sub_dds.uns["mean_disp"] = self.uns["mean_disp"]
         sub_dds.varm["_normed_means"] = sub_dds.layers["normed_counts"].mean(0)
-        sub_dds.varm["fitted_dispersions"] = self.uns["disp_function"](
-            sub_dds.varm["_normed_means"],
+        sub_dds.varm["fitted_dispersions"] = sub_dds.disp_function(
+            sub_dds.varm["_normed_means"]
         )
 
         # Estimate MAP dispersions.
@@ -1108,9 +1117,18 @@ class DeseqDataSet(ad.AnnData):
                 & self.varm["non_zero"]
             ]
 
-            mean_disp = trimmed_mean(
-                self[:, use_for_mean_genes].varm["genewise_dispersions"], trim=0.001
+            if len(use_for_mean_genes) == 0:
+                print(
+                    "No genes have a dispersion above 10 * min_disp in "
+                    "_fit_iterate_size_factors."
+                )
+                break
+
+            mean_disp = trim_mean(
+                self[:, use_for_mean_genes].varm["genewise_dispersions"],
+                proportiontocut=0.001,
             )
+
             self.varm["fitted_dispersions"] = np.ones(self.n_vars) * mean_disp
             self.fit_dispersion_prior()
             self.fit_MAP_dispersions()

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -477,7 +477,7 @@ class DeseqDataSet(ad.AnnData):
             warnings.warn(
                 "Every gene contains at least one zero, "
                 "cannot compute log geometric means. Switching to iterative mode.",
-                RuntimeWarning,
+                UserWarning,
                 stacklevel=2,
             )
             self._fit_iterate_size_factors()

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -602,7 +602,9 @@ class DeseqDataSet(ad.AnnData):
         old_coeffs = pd.Series([0.1, 0.1])
         coeffs = pd.Series([1.0, 1.0])
         try:
-            while (np.log(np.abs(coeffs / old_coeffs)) ** 2).sum() >= 1e-6:
+            while (coeffs > 0).all() and (
+                np.log(np.abs(coeffs / old_coeffs)) ** 2
+            ).sum() >= 1e-6:
                 old_coeffs = coeffs
                 coeffs, predictions = self.inference.dispersion_trend_gamma_glm(
                     covariates, targets

--- a/pydeseq2/default_inference.py
+++ b/pydeseq2/default_inference.py
@@ -203,7 +203,7 @@ class DefaultInference(inference.Inference):
         self, covariates: pd.Series, targets: pd.Series
     ) -> Tuple[np.ndarray, np.ndarray]:
         covariates_w_intercept = covariates.to_frame()
-        covariates_w_intercept["intercept"] = 1
+        covariates_w_intercept.insert(0, "intercept", 1)
         covariates_fit = covariates_w_intercept.values
         targets_fit = targets.values
 

--- a/pydeseq2/default_inference.py
+++ b/pydeseq2/default_inference.py
@@ -1,21 +1,16 @@
-import warnings
 from typing import Literal
 from typing import Optional
 from typing import Tuple
 
 import numpy as np
 import pandas as pd
-import statsmodels.api as sm  # type: ignore
 from joblib import Parallel  # type: ignore
 from joblib import delayed
 from joblib import parallel_backend
-from statsmodels.tools.sm_exceptions import DomainWarning  # type: ignore
+from scipy.optimize import minimize  # type: ignore
 
 from pydeseq2 import inference
 from pydeseq2 import utils
-
-# Ignore DomainWarning raised by statsmodels when fitting a Gamma GLM with identity link.
-warnings.simplefilter("ignore", DomainWarning)
 
 
 class DefaultInference(inference.Inference):
@@ -207,17 +202,34 @@ class DefaultInference(inference.Inference):
     def dispersion_trend_gamma_glm(  # noqa: D102
         self, covariates: pd.Series, targets: pd.Series
     ) -> Tuple[np.ndarray, np.ndarray]:
-        covariates_w_intercept = sm.add_constant(covariates)
-        targets_fit = targets.values
+        covariates_w_intercept = covariates.to_frame()
+        covariates_w_intercept["intercept"] = 1
         covariates_fit = covariates_w_intercept.values
-        glm_gamma = sm.GLM(
-            targets_fit,
-            covariates_fit,
-            family=sm.families.Gamma(link=sm.families.links.identity()),
+        targets_fit = targets.values
+
+        def loss(coeffs):
+            mu = covariates_fit @ coeffs
+            return (targets_fit / mu + np.log(mu)).mean()
+
+        def grad(coeffs):
+            mu = covariates_fit @ coeffs
+            return -(
+                ((targets_fit / mu - 1)[:, None] * covariates_fit) / mu[:, None]
+            ).mean(0)
+
+        res = minimize(
+            loss,
+            x0=np.array([1.0, 1.0]),
+            jac=grad,
+            method="L-BFGS-B",
+            bounds=[(0, np.inf)],
         )
-        res = glm_gamma.fit()
-        coeffs = res.params
-        return (coeffs, covariates_fit @ coeffs)
+
+        if not res.success:
+            raise ValueError("Gamma GLM optimization failed.")
+
+        coeffs = res.x
+        return coeffs, covariates_fit @ coeffs
 
     def lfc_shrink_nbinom_glm(  # noqa: D102
         self,

--- a/pydeseq2/default_inference.py
+++ b/pydeseq2/default_inference.py
@@ -201,7 +201,7 @@ class DefaultInference(inference.Inference):
 
     def dispersion_trend_gamma_glm(  # noqa: D102
         self, covariates: pd.Series, targets: pd.Series
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> Tuple[np.ndarray, np.ndarray, bool]:
         covariates_w_intercept = covariates.to_frame()
         covariates_w_intercept.insert(0, "intercept", 1)
         covariates_fit = covariates_w_intercept.values
@@ -225,11 +225,8 @@ class DefaultInference(inference.Inference):
             bounds=[(0, np.inf)],
         )
 
-        if not res.success:
-            raise RuntimeError("Gamma GLM optimization failed.")
-
         coeffs = res.x
-        return coeffs, covariates_fit @ coeffs
+        return coeffs, covariates_fit @ coeffs, res.success
 
     def lfc_shrink_nbinom_glm(  # noqa: D102
         self,

--- a/pydeseq2/default_inference.py
+++ b/pydeseq2/default_inference.py
@@ -209,13 +209,13 @@ class DefaultInference(inference.Inference):
 
         def loss(coeffs):
             mu = covariates_fit @ coeffs
-            return (targets_fit / mu + np.log(mu)).mean()
+            return np.nanmean(targets_fit / mu + np.log(mu), axis=0)
 
         def grad(coeffs):
             mu = covariates_fit @ coeffs
-            return -(
-                ((targets_fit / mu - 1)[:, None] * covariates_fit) / mu[:, None]
-            ).mean(0)
+            return -np.nanmean(
+                ((targets_fit / mu - 1)[:, None] * covariates_fit) / mu[:, None], axis=0
+            )
 
         res = minimize(
             loss,

--- a/pydeseq2/default_inference.py
+++ b/pydeseq2/default_inference.py
@@ -226,7 +226,7 @@ class DefaultInference(inference.Inference):
         )
 
         if not res.success:
-            raise ValueError("Gamma GLM optimization failed.")
+            raise RuntimeError("Gamma GLM optimization failed.")
 
         coeffs = res.x
         return coeffs, covariates_fit @ coeffs

--- a/pydeseq2/inference.py
+++ b/pydeseq2/inference.py
@@ -285,7 +285,7 @@ class Inference(ABC):
     @abstractmethod
     def dispersion_trend_gamma_glm(
         self, covariates: pd.Series, targets: pd.Series
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> Tuple[np.ndarray, np.ndarray, bool]:
         """Fit a gamma glm on gene dispersions.
 
         The intercept should be concatenated in this method
@@ -304,6 +304,8 @@ class Inference(ABC):
             Coefficients of the regression.
         predictions : ndarray
             Predictions of the regression.
+        converged : bool
+            Whether the optimization converged.
         """
 
     @abstractmethod

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -1547,9 +1547,9 @@ def lowess(
     Parameters
     ----------
     features : ndarray
-        Data points.
+        A 1D array of data points.
     targets : ndarray
-        Target values.
+        A 1D array of target values (with the same shape as features).
     frac : float
         The fraction of the data used when estimating each y-value. (default: ``2/3``).
     iter : int

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -1540,7 +1540,7 @@ def lowess(
     The arrays features and targets contain an equal number of elements; each pair
     (features[i], targets[i]) defines a data point in the scatterplot. The function
     returns the estimated (smooth) values of targets.
-    The smoothing span is given by f. A larger value for f will result in a
+    The smoothing span is given by frac. A larger value for frac will result in a
     smoother curve. The number of robustifying iterations is given by iter. The
     function will run faster with a smaller number of iterations.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,5 @@ convention = "numpy"
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
-    "ignore::DeprecationWarning:patsy[.*]", # due to patsy being a dependency of statsmodels and
-    # calling pandas.core.dtypes.common.is_categorical_dtype.
-    "ignore::DeprecationWarning:statsmodels", # ignore Pyarrow deprecation warnings
-    "ignore::statsmodels.tools.sm_exceptions.DomainWarning", # due to fitting the dipersion curve with the identity link
     "ignore::FutureWarning", # Ignore AnnData FutureWarning about implicit conversion
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ convention = "numpy"
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
-    "ignore::DeprecationWarning:pandas", # ignore Pyarrow deprecation warnings
+    '''ignore:\s*Pyarrow will become a required dependency of pandas:DeprecationWarning''',
+    # ignore Pyarrow deprecation warnings
     "ignore::FutureWarning", # Ignore AnnData FutureWarning about implicit conversion
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,5 +47,6 @@ convention = "numpy"
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
+    "ignore::DeprecationWarning:pandas", # ignore Pyarrow deprecation warnings
     "ignore::FutureWarning", # Ignore AnnData FutureWarning about implicit conversion
 ]

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "numpy>=1.23.0",
         "pandas>=1.4.0",
         "scikit-learn>=1.1.0",
-        "scipy>=1.8.0",
+        "scipy>=1.11.0",
         "matplotlib>=3.6.2",  # not sure why sphinx_gallery does not work without it
     ],  # external packages as dependencies
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         "pandas>=1.4.0",
         "scikit-learn>=1.1.0",
         "scipy>=1.8.0",
-        "statsmodels",
         "matplotlib>=3.6.2",  # not sure why sphinx_gallery does not work without it
     ],  # external packages as dependencies
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(os.path.join(here, "pydeseq2", "__version__.py"), "r", "utf-8") as fp:
 setup(
     name="pydeseq2",
     version=about["__version__"],
-    python_requires=">=3.8.0",
+    python_requires=">=3.9.0",
     license="MIT",
     description="A python implementation of DESeq2.",
     long_description=readme,

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -468,7 +468,9 @@ def test_zero_inflated():
     counts_df.iloc[idx, :] = 0
 
     dds = DeseqDataSet(counts=counts_df, metadata=metadata)
-    with pytest.warns(RuntimeWarning):
+    with pytest.warns(RuntimeWarning), pytest.warns(UserWarning):
+        # Will warn that each gene contains a zero
+        # and that the parametric curve is not a good fit
         dds.deseq2()
 
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -468,7 +468,7 @@ def test_zero_inflated():
     counts_df.iloc[idx, :] = 0
 
     dds = DeseqDataSet(counts=counts_df, metadata=metadata)
-    with pytest.warns(RuntimeWarning), pytest.warns(UserWarning):
+    with pytest.warns(UserWarning):
         # Will warn that each gene contains a zero
         # and that the parametric curve is not a good fit
         dds.deseq2()


### PR DESCRIPTION
#### Reference Issue or PRs

(Partially) fixes #231, closes #235

#### What does your PR implement? Be specific.

This PR removes pydeseq2's dependence on statsmodels, which has been causing a few bugs recently (and is the reason why the CI currently fails).

Statsmodels was used to:

- fit a gamma GLM in `fit_dispersion_trend` 
    - -> this PR replaces it with a custom implementation based on `scipy.optimize`'s L-BFGS-B (which incidentally solves the negative coefficients issue #231). When the fit fails, the code switches to a mean fit.
- perform multiple test adjustment 
    - -> replaced by [`scipy.stats.false_discovery_control`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.false_discovery_control.html)
- perform lowess (locally weighted regression) in `DeseqStats._independent_filtering` 
    - -> replaced by a custom implementation adapted from @agramfort's [lowess gist](https://gist.github.com/agramfort/850437?permalink_comment_id=3437921)