### PR TITLE
BUG Fix new all zero replace

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -828,12 +828,19 @@ class DeseqDataSet(ad.AnnData):
         self._replace_outliers()
         if not self.quiet:
             print(
-                f"Refitting {sum(self.varm['replaced']) } outliers.\n", file=sys.stderr
+                f"Replacing {sum(self.varm['replaced']) } outlier genes.\n",
+                file=sys.stderr,
             )
 
         if sum(self.varm["replaced"]) > 0:
             # Refit dispersions and LFCs for genes that had outliers replaced
             self._refit_without_outliers()
+        else:
+            # Store the fact that no sample was refitted
+            self.varm["refitted"] = np.full(
+                self.n_vars,
+                False,
+            )
 
     def _fit_MoM_dispersions(self) -> None:
         """Rough method of moments initial dispersions fit.

--- a/pydeseq2/default_inference.py
+++ b/pydeseq2/default_inference.py
@@ -217,13 +217,16 @@ class DefaultInference(inference.Inference):
                 ((targets_fit / mu - 1)[:, None] * covariates_fit) / mu[:, None], axis=0
             )
 
-        res = minimize(
-            loss,
-            x0=np.array([1.0, 1.0]),
-            jac=grad,
-            method="L-BFGS-B",
-            bounds=[(0, np.inf)],
-        )
+        try:
+            res = minimize(
+                loss,
+                x0=np.array([1.0, 1.0]),
+                jac=grad,
+                method="L-BFGS-B",
+                bounds=[(1e-12, np.inf)],
+            )
+        except RuntimeWarning:  # Could happen if the coefficients fall to zero
+            return np.array([np.nan, np.nan]), np.array([np.nan, np.nan]), False
 
         coeffs = res.x
         return coeffs, covariates_fit @ coeffs, res.success

--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -579,7 +579,7 @@ class DeseqStats:
         # maximum cooks sample, don't count this gene as an outlier.
 
         # Take into account whether we already replaced outliers
-        if self.dds.refit_cooks and self.dds.varm["replaced"].sum() > 0:
+        if self.dds.refit_cooks and self.dds.varm["refitted"].sum() > 0:
             cooks_outlier = (
                 (self.dds[use_for_max, :].layers["replace_cooks"] > cooks_cutoff)
                 .any(axis=0)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -472,7 +472,9 @@ def test_new_all_zero_gene():
         design_factors="condition",
         refit_cooks=True,
     )
-    dds.deseq2()
+    with pytest.warns(UserWarning):
+        # Will warn that parametric trend fit failed
+        dds.deseq2()
 
     stat_res = DeseqStats(dds)
     stat_res.summary()

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -444,6 +444,50 @@ def test_few_samples_and_outlier():
     res.summary()
 
 
+def test_new_all_zero_gene():
+    """Test that a gene with only 0 counts after replacement is correctly handled."""
+    counts_df = load_example_data(
+        modality="raw_counts",
+        dataset="synthetic",
+        debug=False,
+    )
+
+    metadata = load_example_data(
+        modality="metadata",
+        dataset="synthetic",
+        debug=False,
+    )
+
+    # Subset samples for speed
+    metadata = metadata.loc[[f"sample{i}" for i in [*range(1, 11), *range(91, 101)]]]
+    counts_df = counts_df.loc[metadata.index]
+
+    # Add a gene with a single outlier value and zeros elsewhere
+    counts_df.loc[:, "geneX"] = 0
+    counts_df.loc["sample100", "geneX"] = 100
+
+    dds = DeseqDataSet(
+        counts=counts_df,
+        metadata=metadata,
+        design_factors="condition",
+        refit_cooks=True,
+    )
+    dds.deseq2()
+
+    stat_res = DeseqStats(dds)
+    stat_res.summary()
+
+    # Check that the outlier gene leads to only zeros and that it is correctly handled
+    # in DeseqStats
+    assert dds.new_all_zeroes_genes.equals(pd.Index(["geneX"]))
+    assert stat_res.results_df.loc["geneX", "baseMean"] == 0
+    assert stat_res.results_df.loc["geneX", "log2FoldChange"] == 0
+    assert stat_res.results_df.loc["geneX", "lfcSE"] == 0
+    assert stat_res.results_df.loc["geneX", "stat"] == 0
+    assert np.isnan(stat_res.results_df.loc["geneX", "pvalue"])
+    assert np.isnan(stat_res.results_df.loc["geneX", "padj"])
+
+
 def test_zero_inflated():
     """
     Test the pydeseq2 throws a RuntimeWarning when there is at least one zero per gene.


### PR DESCRIPTION
#### Reference Issue or PRs

Fixes #237, closes #238

#### What does your PR implement? Be specific.

This PR fixes a bug arising when all genes whose Cooks outliers are replaced lead to all-zero values (cf #237).

To fix this, it introduces (similarly to [DESeq2](https://github.com/thelovelab/DESeq2/blob/0247fd7b814c47853891aefe06a127721927333d/R/core.R#L2492)) a new `varm` field, `"refitted"`, which complements `"replaced"` by indicating whether dispersions and LFCs were refitted for that gene (on top of its having values replaced).

Finally, the faulty example presented in #237 was added to the test suite.