### PR TITLE
BUG add ``continuous_factors`` argument to ``sub_dds``

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -1050,6 +1050,7 @@ class DeseqDataSet(ad.AnnData):
             ),
             metadata=self.obs,
             design_factors=self.design_factors,
+            continuous_factors=self.continuous_factors,
             ref_level=self.ref_level,
             min_mu=self.min_mu,
             min_disp=self.min_disp,


### PR DESCRIPTION
#### Reference Issue or PRs

Fixes #258

#### What does your PR implement? Be specific.

Fixes a bug occurring when genes were refit in a design with continuous variables, due to the ``continuous_factors`` argument not being passed to ``sub_dds``.