### PR TITLE
Fix: latex display in sphinx doc

### DIFF
--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -468,7 +468,7 @@ class DeseqStats:
 
         Useful for looking at log fold-change versus mean expression
         between two groups/samples/etc.
-        Uses matplotlib to emulate make_MA() function in DESeq2 in R.
+        Uses matplotlib to emulate the ``make_MA()`` function in DESeq2 in R.
 
         Parameters
         ----------

--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -274,7 +274,7 @@ class DeseqStats:
     def run_wald_test(self) -> None:
         """Perform a Wald test.
 
-        Get gene-wise p-values for gene over/under-expression.`
+        Get gene-wise p-values for gene over/under-expression.
         """
         num_vars = self.design_matrix.shape[1]
 

--- a/pydeseq2/grid_search.py
+++ b/pydeseq2/grid_search.py
@@ -21,7 +21,7 @@ def vec_nb_nll(counts: np.ndarray, mu: np.ndarray, alpha: np.ndarray) -> np.ndar
 
     alpha : ndarray
         Dispersion of the distribution, s.t. the variance is
-        :math:`\mu + \alpha * \mu^2`.
+        :math:`\mu + \alpha \mu^2`.
 
     Returns
     -------

--- a/pydeseq2/grid_search.py
+++ b/pydeseq2/grid_search.py
@@ -21,13 +21,13 @@ def vec_nb_nll(counts: np.ndarray, mu: np.ndarray, alpha: np.ndarray) -> np.ndar
 
     alpha : ndarray
         Dispersion of the distribution, s.t. the variance is
-        :math:`\\mu + \\alpha * \\mu^2`.
+        :math:`\mu + \alpha * \mu^2`.
 
     Returns
     -------
     ndarray
         Negative log likelihood of the observations counts following
-        :math:`NB(\\mu, \\alpha)`.
+        :math:`NB(\mu, \alpha)`.
     """
     n = len(counts)
     alpha_neg1 = 1 / alpha

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -289,8 +289,8 @@ def build_design_matrix(
 def replace_underscores(factors: List[str]):
     """Replace all underscores from strings in a list by hyphens.
 
-    To be used on design factors to avoid bugs due to the reliance on `str.split("_")`
-    in parts of the code.
+    To be used on design factors to avoid bugs due to the reliance on
+    ``str.split("_")`` in parts of the code.
 
     Parameters
     ----------
@@ -421,7 +421,7 @@ def dnb_nll(counts: np.ndarray, mu: np.ndarray, alpha: float) -> float:
 
     alpha : float
         Dispersion of the distribution,
-        s.t. the variance is :math:`\mu + \alpha * \mu^2`.
+        s.t. the variance is :math:`\mu + \alpha\mu^2`.
 
     Returns
     -------
@@ -1468,7 +1468,7 @@ def make_MA_plot(
 
     Useful for looking at log fold-change versus mean expression
     between two groups/samples/etc.
-    Uses matplotlib to emulate make_MA() function in DESeq2 in R.
+    Uses matplotlib to emulate the ``make_MA()`` function in DESeq2 in R.
 
     Parameters
     ----------

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -339,27 +339,27 @@ def nb_nll(
 
     Mathematically, if ``counts`` is a vector of counting entries :math:`y_i`
     then the likelihood of each entry :math:`y_i` to be drawn from a negative
-    binomial :math:`NB(\\mu, \\alpha)` is [1]
+    binomial :math:`NB(\mu, \alpha)` is [1]
 
     .. math::
-        p(y_i | \\mu, \\alpha) = \\frac{\\Gamma(y_i + \\alpha^{-1})}{
-            \\Gamma(y_i + 1)\\Gamma(\\alpha^{-1})
+        p(y_i | \mu, \alpha) = \frac{\Gamma(y_i + \alpha^{-1})}{
+            \Gamma(y_i + 1)\Gamma(\alpha^{-1})
         }
-        \\left(\\frac{1}{1 + \\alpha \\mu} \\right)^{1/\\alpha}
-        \\left(\\frac{\\mu}{\\alpha^{-1} + \\mu} \\right)^{y_i}
+        \left(\frac{1}{1 + \alpha \mu} \right)^{1/\alpha}
+        \left(\frac{\mu}{\alpha^{-1} + \mu} \right)^{y_i}
 
     As a consequence, assuming there are :math:`n` entries,
     the total negative log-likelihood for ``counts`` is
 
     .. math::
-        \\ell(\\mu, \\alpha) = \\frac{n}{\\alpha} \\log(\\alpha) +
-            \\sum_i \\left \\lbrace
-            - \\log \\left( \\frac{\\Gamma(y_i + \\alpha^{-1})}{
-            \\Gamma(y_i + 1)\\Gamma(\\alpha^{-1})
-        } \\right)
-        + (\\alpha^{-1} + y_i) \\log (\\alpha^{-1} + y_i)
-        - y_i \\log \\mu
-            \\right \\rbrace
+        \ell(\mu, \alpha) = \frac{n}{\alpha} \log(\alpha) +
+            \sum_i \left \lbrace
+            - \log \left( \frac{\Gamma(y_i + \alpha^{-1})}{
+            \Gamma(y_i + 1)\Gamma(\alpha^{-1})
+        } \right)
+        + (\alpha^{-1} + y_i) \log (\alpha^{-1} + y_i)
+        - y_i \log \mu
+            \right \rbrace
 
     This is implemented in this function.
 
@@ -369,17 +369,17 @@ def nb_nll(
         Observations.
 
     mu : ndarray
-        Mean of the distribution :math:`\\mu`.
+        Mean of the distribution :math:`\mu`.
 
     alpha : float or ndarray
-        Dispersion of the distribution :math:`\\alpha`,
-        s.t. the variance is :math:`\\mu + \\alpha \\mu^2`.
+        Dispersion of the distribution :math:`\alpha`,
+        s.t. the variance is :math:`\mu + \alpha \mu^2`.
 
     Returns
     -------
     float or ndarray
         Negative log likelihood of the observations counts
-        following :math:`NB(\\mu, \\alpha)`.
+        following :math:`NB(\mu, \alpha)`.
 
     Notes
     -----
@@ -421,12 +421,12 @@ def dnb_nll(counts: np.ndarray, mu: np.ndarray, alpha: float) -> float:
 
     alpha : float
         Dispersion of the distribution,
-        s.t. the variance is :math:`\\mu + \\alpha * \\mu^2`.
+        s.t. the variance is :math:`\mu + \alpha * \mu^2`.
 
     Returns
     -------
     float
-        Derivative of negative log likelihood of NB w.r.t. :math:`\\alpha`.
+        Derivative of negative log likelihood of NB w.r.t. :math:`\alpha`.
     """
     alpha_neg1 = 1 / alpha
     ll_part = (

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -357,7 +357,7 @@ def nb_nll(
             - \log \left( \frac{\Gamma(y_i + \alpha^{-1})}{
             \Gamma(y_i + 1)\Gamma(\alpha^{-1})
         } \right)
-        + (\alpha^{-1} + y_i) \log (\alpha^{-1} + y_i)
+        + (\alpha^{-1} + y_i) \log (\alpha^{-1} + \mu)
         - y_i \log \mu
             \right \rbrace
 


### PR DESCRIPTION
#### What does your PR implement? Be specific.

- Fix the rendering of latex formula in docstring when making html doc with sphinx, by transforming all "\\" into "\".


I checked the result by rebuilding the doc and checking that the formulae are properly rendered.
Before:
![image](https://github.com/owkin/PyDESeq2/assets/84329436/03f83ef4-053b-4790-bffe-28b63e8d26b9)


After:
![image](https://github.com/owkin/PyDESeq2/assets/84329436/1f3dd961-102d-49d5-bae4-5222133b6bec)


- I did not check whether the formulae were right, but just that they were well-displayed.
--
When compiling the doc, I get the following warning due to cycling import:

```
WARNING: autodoc: failed to import module 'grid_search' from module 'pydeseq2'; the following exception was raised:
cannot import name 'grid_fit_alpha' from partially initialized module 'pydeseq2.grid_search' (most likely due to a circular import) (/Users/owkin/Project/PyDESeq2/pydeseq2/grid_search.py)
```

Indeed `grid_search` imports `utils` and vice versa.  But I don't think it should be solved in this PR.