### PR TITLE
fix : enable vst be used "blindly" and to fit its own dispersion

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -311,7 +311,8 @@ class DeseqDataSet(ad.AnnData):
             If False, only an intercept is used. (default: ``False``).
 
         fit_type: str
-            * ``None``: use the vst_fit_type to fit the dispersions.
+            * ``None``: fit_type provided at initialization to fit
+            the dispersions trend curve.
             * ``"parametric"``: fit a dispersion-mean relation via a robust
               gamma-family GLM.
             * ``"mean"``: use the mean of gene-wise dispersion estimates.
@@ -458,8 +459,8 @@ class DeseqDataSet(ad.AnnData):
             (default: ``None``).
         """
         if fit_type is not None:
-            self.current_fit_type = fit_type
-            print(f"Using {self.current_fit_type} fit type.")
+            self.fit_type = fit_type
+            print(f"Using {self.fit_type} fit type.")
 
         # Compute DESeq2 normalization factors using the Median-of-ratios method
         self.fit_size_factors()

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -310,11 +310,14 @@ class DeseqDataSet(ad.AnnData):
         use_design : bool
             Whether to use the full design matrix to fit dispersions and the trend curve.
             If False, only an intercept is used. (default: ``False``).
+
         fit_type: str
-            - None : use the trend_fit_type to fit the dispersions
-            - "parametric" : fit a dispersion-mean relation via a robust gamma-family GLM
-            - "mean" : use the mean of gene-wise dispersion estimates
-            (default: ``None``)
+            - ``None``: use the trend_fit_type to fit the dispersions
+            - ``"parametric"``: fit a dispersion-mean relation via a robust
+              gamma-family GLM
+            - ``"mean"``: use the mean of gene-wise dispersion estimates
+
+            (default: ``None``).
         """
         if fit_type is not None:
             self.trend_fit_type = fit_type

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -750,11 +750,9 @@ class DeseqDataSet(ad.AnnData):
 
         # Filter outlier genes for which we won't apply shrinkage
         self.varm["dispersions"] = self.varm["MAP_dispersions"].copy()
-        self.varm["_outlier_genes"] = np.log(
-            self.varm["genewise_dispersions"]
-        ) > np.log(self.varm["fitted_dispersions"]) + 2 * np.sqrt(
-            self.uns["_squared_logres"]
-        )
+        self.varm["_outlier_genes"] = np.log(self.varm["genewise_dispersions"]) > np.log(
+            self.varm["fitted_dispersions"]
+        ) + 2 * np.sqrt(self.uns["_squared_logres"])
         self.varm["dispersions"][self.varm["_outlier_genes"]] = self.varm[
             "genewise_dispersions"
         ][self.varm["_outlier_genes"]]
@@ -1172,9 +1170,7 @@ class DeseqDataSet(ad.AnnData):
         sub_dds.fit_LFC()
 
         # Replace values in main object
-        self.varm["_normed_means"][self.varm["refitted"]] = sub_dds.varm[
-            "_normed_means"
-        ]
+        self.varm["_normed_means"][self.varm["refitted"]] = sub_dds.varm["_normed_means"]
         self.varm["LFC"][self.varm["refitted"]] = sub_dds.varm["LFC"]
         self.varm["genewise_dispersions"][self.varm["refitted"]] = sub_dds.varm[
             "genewise_dispersions"
@@ -1269,9 +1265,7 @@ class DeseqDataSet(ad.AnnData):
             ) < 1e-4:
                 break
             elif i == niter - 1:
-                print(
-                    "Iterative size factor fitting did not converge.", file=sys.stderr
-                )
+                print("Iterative size factor fitting did not converge.", file=sys.stderr)
 
         # Restore the design matrix and free buffer
         self.obsm["design_matrix"] = self.obsm["design_matrix_buffer"].copy()

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -72,8 +72,8 @@ class DeseqDataSet(ad.AnnData):
         we're testing, e.g. ``["condition", "A"]``. (default: ``None``).
 
     fit_type: str
-        Either "parametric" or "mean" for the type of fitting of dispersions to the
-        mean intensity. "parametric": fit a dispersion-mean relation via a robust
+        Either ``"parametric"`` or ``"mean"`` for the type of fitting of dispersions to
+        the mean intensity. "parametric": fit a dispersion-mean relation via a robust
         gamma-family GLM. "mean": use the mean of gene-wise dispersion estimates.
         (default: ``"parametric"``).
         Will set the fit type for the DEA and the vst transformation. If needed,
@@ -315,7 +315,6 @@ class DeseqDataSet(ad.AnnData):
             - ``"parametric"``: fit a dispersion-mean relation via a robust
               gamma-family GLM
             - ``"mean"``: use the mean of gene-wise dispersion estimates
-
             (default: ``None``).
         """
         if fit_type is not None:
@@ -437,7 +436,7 @@ class DeseqDataSet(ad.AnnData):
             ) / np.log(2)
         else:
             raise NotImplementedError(
-                f"Found fit_type '{self.fit_type}'." " Expected 'parametric' or 'mean'."
+                f"Found fit_type '{self.fit_type}'. Expected 'parametric' or 'mean'."
             )
 
     def deseq2(self, fit_type: Optional[Literal["parametric", "mean"]] = None) -> None:
@@ -446,10 +445,10 @@ class DeseqDataSet(ad.AnnData):
         Parameters
         ----------
         fit_type : str
-            Either None, "parametric" or "mean" for the type of fitting of dispersions
-            to the mean intensity. parametric - fit a dispersion-mean relation via a
-            robust gamma-family GLM. mean - use the mean of gene-wise dispersion
-            estimates. (default: ``None``).
+            Either None, ``"parametric"`` or ``"mean"`` for the type of fitting of
+            dispersions to the mean intensity. parametric - fit a dispersion-mean
+            relation via a robust gamma-family GLM. mean - use the mean of gene-wise
+            dispersion estimates. (default: ``None``).
             If None, the fit_type provided at class initialization is used.
 
         Wrapper for the first part of the PyDESeq2 pipeline.

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -73,11 +73,10 @@ class DeseqDataSet(ad.AnnData):
 
     fit_type: str
         Either ``"parametric"`` or ``"mean"`` for the type of fitting of dispersions to
-        the mean intensity. "parametric": fit a dispersion-mean relation via a robust
-        gamma-family GLM. "mean": use the mean of gene-wise dispersion estimates.
-        (default: ``"parametric"``).
-        Will set the fit type for the DEA and the vst transformation. If needed,
-        it can be set separately for each method.
+        the mean intensity. ``"parametric"``: fit a dispersion-mean relation via a
+        robust gamma-family GLM. ``"mean"``: use the mean of gene-wise dispersion
+        estimates. Will set the fit type for the DEA and the vst transformation. If
+        needed, it can be set separately for each method.(default: ``"parametric"``).
 
     min_mu : float
         Threshold for mean estimates. (default: ``0.5``).
@@ -172,6 +171,7 @@ class DeseqDataSet(ad.AnnData):
     ----------
     .. bibliography::
         :keyprefix: DeseqDataSet-
+
     """
 
     def __init__(
@@ -311,10 +311,11 @@ class DeseqDataSet(ad.AnnData):
             If False, only an intercept is used. (default: ``False``).
 
         fit_type: str
-            - ``None``: use the vst_fit_type to fit the dispersions
-            - ``"parametric"``: fit a dispersion-mean relation via a robust
-              gamma-family GLM
-            - ``"mean"``: use the mean of gene-wise dispersion estimates
+            * ``None``: use the vst_fit_type to fit the dispersions.
+            * ``"parametric"``: fit a dispersion-mean relation via a robust
+              gamma-family GLM.
+            * ``"mean"``: use the mean of gene-wise dispersion estimates.
+
             (default: ``None``).
         """
         if fit_type is not None:
@@ -442,16 +443,19 @@ class DeseqDataSet(ad.AnnData):
     def deseq2(self, fit_type: Optional[Literal["parametric", "mean"]] = None) -> None:
         """Perform dispersion and log fold-change (LFC) estimation.
 
+        Wrapper for the first part of the PyDESeq2 pipeline.
+
+
         Parameters
         ----------
         fit_type : str
             Either None, ``"parametric"`` or ``"mean"`` for the type of fitting of
-            dispersions to the mean intensity. parametric - fit a dispersion-mean
-            relation via a robust gamma-family GLM. mean - use the mean of gene-wise
-            dispersion estimates. (default: ``None``).
-            If None, the fit_type provided at class initialization is used.
+            dispersions to the mean intensity.``"parametric"``: fit a dispersion-mean
+            relation via a robust gamma-family GLM. ``"mean"``: use the mean of
+            gene-wise dispersion estimates.
 
-        Wrapper for the first part of the PyDESeq2 pipeline.
+            If None, the fit_type provided at class initialization is used.
+            (default: ``None``).
         """
         if fit_type is not None:
             self.current_fit_type = fit_type

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -312,7 +312,7 @@ class DeseqDataSet(ad.AnnData):
 
         fit_type: str
             * ``None``: fit_type provided at initialization to fit
-            the dispersions trend curve.
+              the dispersions trend curve.
             * ``"parametric"``: fit a dispersion-mean relation via a robust
               gamma-family GLM.
             * ``"mean"``: use the mean of gene-wise dispersion estimates.

--- a/tests/test_pydeseq2.py
+++ b/tests/test_pydeseq2.py
@@ -744,7 +744,7 @@ def test_vst_fit(train_dds):
     train_dds.vst_fit()
 
     # the correct attributes are fit
-    assert "trend_coeffs" in train_dds.uns
+    assert "vst_trend_coeffs" in train_dds.uns
     assert "normed_counts" in train_dds.layers
     assert "size_factors" in train_dds.obsm
 
@@ -769,7 +769,7 @@ def test_vst_transform(train_dds, test_counts):
     ],
 )
 def test_vst_blind(train_counts, train_metadata, dea_fit_type, vst_fit_type):
-    """Test vst with combinatory dea dea_fit_type and vst_fit_type"""
+    """Test vst with combinatory dea dea_fit_type and fit_type"""
     train_dds = DeseqDataSet(
         counts=train_counts,
         metadata=train_metadata,
@@ -786,7 +786,8 @@ def test_vst_blind(train_counts, train_metadata, dea_fit_type, vst_fit_type):
     assert train_dds.fit_type == dea_fit_type
 
     train_dds.vst(use_design=False, fit_type=vst_fit_type)
-    assert train_dds.fit_type == vst_fit_type
+    # Check that the dea fit type hasn't changed
+    assert train_dds.fit_type == dea_fit_type
 
 
 def test_vst_transform_no_fit(train_counts, train_metadata, test_counts):

--- a/tests/test_pydeseq2.py
+++ b/tests/test_pydeseq2.py
@@ -51,7 +51,7 @@ def test_deseq_independent_filtering_parametric_fit(counts_df, metadata, tol=0.0
         counts=counts_df,
         metadata=metadata,
         design_factors="condition",
-        trend_fit_type="parametric",
+        fit_type="parametric",
     )
     dds.deseq2()
 
@@ -79,7 +79,7 @@ def test_deseq_independent_filtering_mean_fit(counts_df, metadata, tol=0.02):
         counts=counts_df,
         metadata=metadata,
         design_factors="condition",
-        trend_fit_type="mean",
+        fit_type="mean",
     )
     dds.deseq2()
 
@@ -112,7 +112,7 @@ def test_deseq_without_independent_filtering_parametric_fit(
         counts=counts_df,
         metadata=metadata,
         design_factors="condition",
-        trend_fit_type="parametric",
+        fit_type="parametric",
     )
     dds.deseq2()
 
@@ -760,7 +760,7 @@ def test_vst_transform(train_dds, test_counts):
 
 
 @pytest.mark.parametrize(
-    ("trend_fit_type", "vst_fit_type"),
+    ("dea_fit_type", "vst_fit_type"),
     [
         ("mean", "parametric"),
         ("parametric", "mean"),
@@ -768,25 +768,25 @@ def test_vst_transform(train_dds, test_counts):
         ("mean", "mean"),
     ],
 )
-def test_vst_blind(train_counts, train_metadata, trend_fit_type, vst_fit_type):
-    """Test vst with combinatory dea trend_fit_type and vst_fit_type"""
+def test_vst_blind(train_counts, train_metadata, dea_fit_type, vst_fit_type):
+    """Test vst with combinatory dea dea_fit_type and vst_fit_type"""
     train_dds = DeseqDataSet(
         counts=train_counts,
         metadata=train_metadata,
         design_factors="condition",
-        trend_fit_type=trend_fit_type,
+        fit_type=dea_fit_type,
     )
     train_dds.deseq2()
-    if trend_fit_type == "parametric":
+    if dea_fit_type == "parametric":
         assert "trend_coeffs" in train_dds.uns
     else:
         assert "mean_disp" in train_dds.uns
     assert "normed_counts" in train_dds.layers
     assert "size_factors" in train_dds.obsm
-    assert train_dds.trend_fit_type == trend_fit_type
+    assert train_dds.fit_type == dea_fit_type
 
     train_dds.vst(use_design=False, fit_type=vst_fit_type)
-    assert train_dds.trend_fit_type == vst_fit_type
+    assert train_dds.fit_type == vst_fit_type
 
 
 def test_vst_transform_no_fit(train_counts, train_metadata, test_counts):
@@ -795,7 +795,7 @@ def test_vst_transform_no_fit(train_counts, train_metadata, test_counts):
         counts=train_counts,
         metadata=train_metadata,
         design_factors="condition",
-        trend_fit_type="parametric",
+        fit_type="parametric",
     )
     with pytest.raises(RuntimeError):
         train_dds.vst_transform(test_counts.to_numpy())


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://pydeseq2.readthedocs.io/en/latest/usage/contributing.html
Make sure that you have added unit tests if applicable.
-->

#### Reference Issue or PRs
<!--
If this PR is related to an existing issue or PR please reference it, eg:
Fixes #1234.
You can use github keywords as described:
https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fix #263

#### What does your PR implement? Be specific.
Proposed solution :

- A `self.fit_type` is defined at class initialisation and will by default set the fit_type for DEA and VST.
- If needed, a fit type can be passed to deseq2() and vst() in order to launch the two analysis with a separate fit_type. It will set self.fit_type to the user one.
- self.vst_fit() and self.vst_transform() will call internally the self.fit_type.
- vst_transform() should always be called after vst_fit() or deseq2(). Raise an exception if needed trend_coef have not been computed by deseq2() or vst_fit()
- Add unit tests
