### PR TITLE
BUG update genewise dispersions and fitted dispersions of refitted genes

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -1096,6 +1096,12 @@ class DeseqDataSet(ad.AnnData):
         # Replace values in main object
         self.varm["_normed_means"][self.varm["refitted"]] = sub_dds.varm["_normed_means"]
         self.varm["LFC"][self.varm["refitted"]] = sub_dds.varm["LFC"]
+        self.varm["genewise_dispersions"][self.varm["refitted"]] = sub_dds.varm[
+            "genewise_dispersions"
+        ]
+        self.varm["fitted_dispersions"][self.varm["refitted"]] = sub_dds.varm[
+            "fitted_dispersions"
+        ]
         self.varm["dispersions"][self.varm["refitted"]] = sub_dds.varm["dispersions"]
 
         replace_cooks = pd.DataFrame(self.layers["cooks"].copy())


### PR DESCRIPTION
#### What does your PR implement? Be specific.

Currently, when outlier genes are refitted, only `"_normed_means"`, `"LFC"` and `"dispersions"` are updated in the fields of the `DeseqDataSet`, but not `"genewise_dispersions"` and `"fitted_dispersions"`.

This has limited or no impact on the remainder of the code, but interferes with visualisation (e.g. with `plot_dispersions()`. 

This PR fixes this by also updating `"genewise_dispersions"` and `"fitted_dispersions"`.

#### Example

Before:

<img width="1111" alt="Capture d’écran 2024-04-24 à 10 20 25" src="https://github.com/owkin/PyDESeq2/assets/11092154/0ca68d62-b162-4668-8cd7-bd53be50020a">

After:

<img width="1108" alt="Capture d’écran 2024-04-24 à 10 42 06" src="https://github.com/owkin/PyDESeq2/assets/11092154/0d688df6-a287-4153-9fe1-efc3bd59bccb">
