### PR TITLE
BUG initialize `beta_init` when the design matrix is not full rank

### DIFF
--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -524,8 +524,9 @@ def irls_solver(
         beta_init = solve(R, Q.T @ y)
         beta = beta_init
     else:  # Initialise intercept with log base mean
-        beta = np.zeros(num_vars)
-        beta[0] = np.log(counts / size_factors).mean()
+        beta_init = np.zeros(num_vars)
+        beta_init[0] = np.log(counts / size_factors).mean()
+        beta = beta_init
 
     dev = 1000.0
     dev_ratio = 1.0


### PR DESCRIPTION
#### Reference Issue or PRs

Fixes #280 

#### What does your PR implement? Be specific.

Initialize `beta_init` in irls even when the design matrix is not full rank.

This prevents a `referenced before assignment` error in the case where irls is run with a rank-deficient design matrix and irls starts diverging.