### PR TITLE
Fix Inference n_cpus overwritten issue

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -284,7 +284,8 @@ class DeseqDataSet(ad.AnnData):
 
         if inference:
             if hasattr(inference, "n_cpus"):
-                inference.n_cpus = n_cpus
+                if n_cpus:
+                    inference.n_cpus = n_cpus
             else:
                 warnings.warn(
                     "The provided inference object does not have an n_cpus "


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://pydeseq2.readthedocs.io/en/latest/usage/contributing.html
Make sure that you have added unit tests if applicable.
-->

#### Reference Issue or PRs
<!--
If this PR is related to an existing issue or PR please reference it, eg:
Fixes #1234.
You can use github keywords as described:
https://github.com/blog/1506-closing-issues-via-pull-requests
-->

This PR is to fix Issue #288 .

#### What does your PR implement? Be specific.

The current initialization of `DeseqDataSet` always overwrites its `Inference` object's `n_cpus`. So no matter which value is specified for `n_cpus` when declaring an `Inference` object, when passed to `DeseqDataSet`, its `n_cpus` is always overwritten to use all available vCPUs.

My implementation just restricts that Inference's `n_cpus` can only be overwritten if DeseqDataSet's `n_cpus` is not `None`.

