### PR TITLE
BUG: creating columns on all levels even for continuous

### DIFF
--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -253,7 +253,7 @@ def build_design_matrix(
 
         if not expanded:
             # Add reference level as column name suffix
-            for factor in design_factors:
+            for factor in categorical_factors:
                 if ref_level is None or factor != ref_level[0]:
                     # The reference is the unique level that is no longer there
                     ref = next(


### PR DESCRIPTION
#### What does your PR implement? Be specific.

This PR fixes a bug I noticed in the creation of the design matrix. In the original implementation, one column would be created for all levels of **all** design factors whereas we would like this to be the case only for categorical variables. This is fixed in this PR 

