### PR TITLE
MAINT cast counts to int when initialising a DeseqDataSet from anndata

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -208,6 +208,8 @@ class DeseqDataSet(ad.AnnData):
             test_valid_counts(adata.X)
             # Copy fields from original AnnData
             self.__dict__.update(adata.__dict__)
+            # Cast counts to ints to avoid any issue
+            self.X = adata.X.astype(int)
         elif counts is not None and metadata is not None:
             # Test counts before going further
             test_valid_counts(counts)


### PR DESCRIPTION
#### Reference Issue or PRs

Related to #291

#### What does your PR implement? Be specific.

When we create a DeseqDataSet from a counts and a metadata dataframes, counts are automatically cast to int, but not when we create one from a pre-existing anndata object. 

This may apparently cause bugs (cf. #291). 

This PR fixes this by casting anndata counts to int by default.