### PR TITLE
Add Relative Log Expression (RLE) Plots

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -21,6 +21,7 @@ from pydeseq2.preprocessing import deseq2_norm_fit
 from pydeseq2.preprocessing import deseq2_norm_transform
 from pydeseq2.utils import build_design_matrix
 from pydeseq2.utils import dispersion_trend
+from pydeseq2.utils import make_rle_plot
 from pydeseq2.utils import make_scatter
 from pydeseq2.utils import mean_absolute_deviation
 from pydeseq2.utils import n_or_more_replicates
@@ -1006,6 +1007,36 @@ class DeseqDataSet(ad.AnnData):
             legend_labels=legend_labels,
             x_val=self.varm["_normed_means"],
             log=log,
+            save_path=save_path,
+            **kwargs,
+        )
+
+    def plot_rle(
+        self,
+        normalize: bool = False,
+        save_path: Optional[str] = None,
+        **kwargs,
+    ):
+        """Plot ratio of log expressions for each sample.
+
+        Useful for visualizing sample to sample variation.
+
+        Parameters
+        ----------
+        normalize : bool, optional
+            Whether to normalize the counts before plotting. (default: ``False``).
+
+        save_path : str or None
+            The path where to save the plot. If left None, the plot won't be saved
+            (default: ``None``).
+
+        **kwargs
+            Keyword arguments for the scatter plot.
+        """
+        make_rle_plot(
+            count_matrix=self.X,
+            normalize=normalize,
+            sample_ids=self.obsm["design_matrix"].index,
             save_path=save_path,
             **kwargs,
         )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://pydeseq2.readthedocs.io/en/latest/usage/contributing.html
Make sure that you have added unit tests if applicable.
-->

#### Reference Issue or PRs
<!--
If this PR is related to an existing issue or PR please reference it, eg:
Fixes #1234.
You can use github keywords as described:
https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Issue Reference: https://github.com/owkin/PyDESeq2/issues/320

#### What does your PR implement? Be specific.
The Relative Log Expression (RLE) is a useful diagnostic plot to visualize the differences in count distributions between samples. The x-axis is each sample from the count matrix and the y-axis is the log difference between each gene and the median expression of that gene across all samples.

Given:

`gene_ij` is the expression of gene `j` in sample `i`
`median_j` is the median expression of gene `j` across all samples
The RLE for gene `j` in sample `i` is calculated as:

```
RLE_ij = Log2(gene_ij/median_j)
```

Where:

`gene_{ij} `is the count of gene `j` in sample `i`
`median_j` is the median count of gene j across all samples

This issue takes in the raw counts `self.X`, a `normalize` boolean, `design_matrix.index` for the sample_ids, and a `save_path` and produces an RLE plot. 

![rle_plot](https://github.com/user-attachments/assets/35f5abd8-7ec3-4393-a4eb-cf95acf82d65)

The normalize boolean is set to `False` by default but can be set to `True` to normalize the raw counts before plotting

![nlog_rle_plot](https://github.com/user-attachments/assets/4a1b6d0f-ac52-4aac-a1b3-0dabc4e40148)

This example was produced with the synthetic data in the `./datasets/` dir


