### PR TITLE
changed @ to dot

### DIFF
--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -305,7 +305,7 @@ class DeseqStats:
                 )
 
         mu = (
-            np.exp(self.design_matrix @ self.LFC.T)
+            np.exp(self.design_matrix.dot(self.LFC.T))
             .multiply(self.dds.obsm["size_factors"], 0)
             .values
         )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://pydeseq2.readthedocs.io/en/latest/usage/contributing.html
Make sure that you have added unit tests if applicable.
-->

#### Reference Issue or PRs
<!--
If this PR is related to an existing issue or PR please reference it, eg:
Fixes #1234.
You can use github keywords as described:
https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does your PR implement? Be specific.

Instead of using '@' for matrix multiplication I wanted to use the pandas function pd.dot.
This effectively changes nothing in the underlying functionality or usage of the package.

However I suppress the syntactic sugar of @ with pandas so that I can use '@' for other purposes.
If the choice of using syntactic sugar is by design then it is understandable why this PR may be rejected.