### PR TITLE
MAINT fix quiet mode

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -1389,6 +1389,7 @@ class DeseqDataSet(ad.AnnData):
             min_replicates=self.min_replicates,
             beta_tol=self.beta_tol,
             inference=self.inference,
+            quiet=self.quiet,
         )
 
         # Use the same size factors

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -374,7 +374,8 @@ class DeseqDataSet(ad.AnnData):
         else:
             self.vst_fit_type = self.fit_type
 
-        print(f"Fit type used for VST : {self.vst_fit_type}")
+        if not self.quiet:
+            print(f"Fit type used for VST : {self.vst_fit_type}")
 
         self.vst_fit(use_design=use_design)
         self.layers["vst_counts"] = self.vst_transform()
@@ -526,7 +527,8 @@ class DeseqDataSet(ad.AnnData):
         """
         if fit_type is not None:
             self.fit_type = fit_type
-            print(f"Using {self.fit_type} fit type.")
+            if not self.quiet:
+                print(f"Using {self.fit_type} fit type.")
 
         # Compute DESeq2 normalization factors using the Median-of-ratios method
         self.fit_size_factors(
@@ -1492,6 +1494,7 @@ class DeseqDataSet(ad.AnnData):
             ]
 
             if len(use_for_mean_genes) == 0:
+                # TODO: this should be a warning, or printed to stderr
                 print(
                     "No genes have a dispersion above 10 * min_disp in "
                     "_fit_iterate_size_factors."

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -1494,10 +1494,10 @@ class DeseqDataSet(ad.AnnData):
             ]
 
             if len(use_for_mean_genes) == 0:
-                # TODO: this should be a warning, or printed to stderr
                 print(
                     "No genes have a dispersion above 10 * min_disp in "
-                    "_fit_iterate_size_factors."
+                    "_fit_iterate_size_factors.",
+                    file=sys.stderr,
                 )
                 break
 

--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -442,9 +442,7 @@ class DeseqStats:
             self.results_df["log2FoldChange"] = self.LFC.iloc[:, coeff_idx] / np.log(2)
             self.results_df["lfcSE"] = self.SE / np.log(2)
             if not self.quiet:
-                # The factor is continuous
                 print(f"Shrunk log2 fold change & Wald test p-value: {coeff}")
-            if not self.quiet:
                 print(self.results_df)
 
     def plot_MA(self, log: bool = True, save_path: str | None = None, **kwargs):


### PR DESCRIPTION
#### Reference Issue or PRs
Fixes #287 

#### What does your PR implement? Be specific.

This PR ensures that no non-warning statements are printed in quiet mode. Main changes:

- The `quiet` attribute is passed to `sub_dds` in the cooks refitting step
- VST methods are now silent when `quiet=True`