### PR TITLE
Fix pandas 3 data type and copy/write bugs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -230,6 +230,7 @@ epub_exclude_files = ["search.html"]
 nitpick_ignore = [
     ("py:class", "pd.Series"),
     ("py:class", "pd.DataFrame"),
+    ("py:class", "pandas.core.frame.DataFrame"),
     ("py:class", "ndarray"),
     ("py:class", "numpy._typing._generic_alias.ScalarType"),
     ("py:class", "pydantic.main.BaseModel"),

--- a/pydeseq2/grid_search.py
+++ b/pydeseq2/grid_search.py
@@ -42,13 +42,13 @@ def vec_nb_nll(
             -logbinom
             + (counts[:, None] + alpha_neg1) * np.log(mu[:, None] + alpha_neg1)
             - (counts * np.log(mu))[:, None]
-        ).sum(0)
+        ).sum(axis=0)
     else:
         return n * alpha_neg1 * np.log(alpha) + (
             -logbinom
             + (counts[:, None] + alpha_neg1) * np.log(mu + alpha_neg1)
             - (counts[:, None] * np.log(mu))
-        ).sum(0)
+        ).sum(axis=0)
 
 
 def grid_fit_alpha(

--- a/pydeseq2/preprocessing.py
+++ b/pydeseq2/preprocessing.py
@@ -49,7 +49,7 @@ def deseq2_norm_fit(counts: pd.DataFrame | np.ndarray) -> tuple[np.ndarray, np.n
     # Compute gene-wise mean log counts
     with np.errstate(divide="ignore"):  # ignore division by zero warnings
         log_counts = np.log(counts)
-    logmeans = log_counts.mean(0)
+    logmeans = log_counts.mean(axis=0)
     # Filter out genes with -∞ log means
     filtered_genes = ~np.isinf(logmeans)
 

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -222,7 +222,7 @@ def nb_nll(
             - logbinom
             + (counts + alpha_neg1) * np.log(mu + alpha_neg1)
             - (counts * np.log(mu))
-        ).sum(0)
+        ).sum(axis=0)
     else:
         return (
             n * alpha_neg1 * np.log(alpha)
@@ -849,7 +849,7 @@ def fit_rough_dispersions(
     y_hat = np.maximum(y_hat, 1)
     alpha_rde = (
         ((normed_counts - y_hat) ** 2 - y_hat) / ((num_samples - num_vars) * y_hat**2)
-    ).sum(0)
+    ).sum(axis=0)
     return np.maximum(alpha_rde, 0)
 
 
@@ -877,7 +877,7 @@ def fit_moments_dispersions(
     # Exclude genes with all zeroes
     normed_counts = normed_counts[:, ~(normed_counts == 0).all(axis=0)]
     # mean inverse size factor
-    s_mean_inv = (1 / size_factors).mean()
+    s_mean_inv = (1 / size_factors).mean(axis=0)
     mu = normed_counts.mean(0)
     sigma = normed_counts.var(0, ddof=1)
     # ddof=1 is to use an unbiased estimator, as in R
@@ -951,7 +951,7 @@ def robust_method_of_moments_disp(
             np.ndarray, trimmed_variance(normed_counts)
         )  # Since normed_counts is always 2D, trimmed_variance returns ndarray
 
-    m = normed_counts.mean(0)
+    m = normed_counts.mean(axis=0)
     alpha = (v - m) / m**2
     # cannot use the typical min_disp = 1e-8 here or else all counts in the same
     # group as the outlier count will get an extreme Cook's distance
@@ -1202,7 +1202,7 @@ def nbinomFn(
 
     nll = (
         counts * xbeta - (counts + size) * np.logaddexp(xbeta + offset, np.log(size))
-    ).sum(0)
+    ).sum(axis=0)
 
     return prior - nll
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "pydeseq2"
-version = "0.5.3"
+version = "0.5.4"
 description = "A python implementation of DESeq2."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
#### Reference Issue or PRs
See: https://scverse.zulipchat.com/#narrow/channel/316218-repo-management/topic/Upcoming.20Pandas.203.2E0.2E0.20release/with/569443597


#### What does your PR implement? Be specific.
Fixes pandas 3 (now released) incompatibility due to bool to float conversion & update on copy of DataFrame errors as well as explicit keyword arguments on mean/sum.

- Version bumped to 0.5.4, as there should be no incompatibilies.
- Changed all instances of `.sum(0)/.mean(0)/.sum()/.mean()` to `.sum(axis=0)/.mean(axis=0)
- Initialized convergence tracking columns with nullable boolean pd.array instead of float64 np.array with np.nan, so that bool assignments are possible without conversion / error
- Changed LFC shrinkage update, since in pandas 3 it would update a copy (views are now copies) instead of the original df. Since there is the *theoretic* possibility of SE/LFC being NaN or inifinite after shrinkage, implemented a isfinite check to match previous behavior of only updating on non-NaN values. However, since I personally find this to be unexpected behavior (I would not expect lfc_shrink to silently perform partial shrinkage), I have now added a warning informing users when partial shrinkage occurs (should be almost never, but I cannot exclude that this cannot happen).
- I have build the docs & compared all LFC array prints in the notebooks to the previous version and they match 1:1 and all tests are passing.