### PR TITLE
docs: fix broken intersphinx links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -238,6 +238,10 @@ nitpick_ignore = [
     # anndata re-exports AnnData from a private submodule; autodoc resolves the
     # runtime path for base-class references which intersphinx cannot remap.
     ("py:class", "anndata._core.anndata.AnnData"),
+    # pandas re-exports DataFrame from pandas.core.frame, but intersphinx only
+    # knows the public path (pandas.DataFrame). autodoc resolves type annotations
+    # like `pd.DataFrame` to the internal module path at runtime.
+    ("py:class", "pandas.core.frame.DataFrame"),
     ("py:class", "numpy._typing._generic_alias.ScalarType"),
     ("py:class", "pydantic.main.BaseModel"),
     ("py:class", "torch.nn.modules.module.Module"),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -113,6 +113,13 @@ napoleon_type_aliases = {
     "Inference": ":class:`Inference <pydeseq2.inference.Inference>`",
     "DefaultInference": ":class:`DefaultInference "
     "<pydeseq2.default_inference.DefaultInference>`",
+    # numpy short forms
+    "ndarray": ":class:`numpy.ndarray`",
+    "np.ndarray": ":class:`numpy.ndarray`",
+    # pandas short forms
+    "pd.DataFrame": ":class:`pandas.DataFrame`",
+    "pd.Series": ":class:`pandas.Series`",
+    "pandas.Index": ":class:`pandas.Index`",
 }
 
 # Add any paths that contain templates here, relative to this directory.
@@ -228,10 +235,9 @@ epub_exclude_files = ["search.html"]
 # documentation for each type specified
 # The following elements are the link that auto doc were not able to do
 nitpick_ignore = [
-    ("py:class", "pd.Series"),
-    ("py:class", "pd.DataFrame"),
-    ("py:class", "pandas.core.frame.DataFrame"),
-    ("py:class", "ndarray"),
+    # anndata re-exports AnnData from a private submodule; autodoc resolves the
+    # runtime path for base-class references which intersphinx cannot remap.
+    ("py:class", "anndata._core.anndata.AnnData"),
     ("py:class", "numpy._typing._generic_alias.ScalarType"),
     ("py:class", "pydantic.main.BaseModel"),
     ("py:class", "torch.nn.modules.module.Module"),


### PR DESCRIPTION
## Summary

- Add `napoleon_type_aliases` for short-form types (`ndarray`, `pd.DataFrame`, `pd.Series`, `np.ndarray`, `pandas.Index`) so Napoleon maps them to fully qualified intersphinx targets
- Remove `pd.Series`, `pd.DataFrame`, `pandas.core.frame.DataFrame`, and `ndarray` from `nitpick_ignore` since intersphinx now resolves them correctly
- Add `anndata._core.anndata.AnnData` to `nitpick_ignore` (autodoc resolves the runtime module path for base-class references, which intersphinx cannot remap)

Closes #437

## Test plan

- [x] `make html` in `docs/` builds with zero warnings