### PR TITLE
Fix AttributeError when design is a DataFrame

### DIFF
--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -575,11 +575,25 @@ class DeseqDataSet(ad.AnnData):
         ndarray
             A contrast vector that aligns to the columns of the design matrix.
         """
-        return self.formulaic_contrasts.cond(**kwargs)
+        try:
+            return self.formulaic_contrasts.cond(**kwargs)
+        except AttributeError:
+            raise AttributeError(
+                "The cond() method requires a formula-based design. "
+                "When using a precomputed design matrix (DataFrame), "
+                "pass the contrast vector directly instead."
+            ) from None
 
     def contrast(self, *args, **kwargs):
         """Get a contrast for a simple pairwise comparison."""
-        return self.formulaic_contrasts.contrast(*args, **kwargs)
+        try:
+            return self.formulaic_contrasts.contrast(*args, **kwargs)
+        except AttributeError:
+            raise AttributeError(
+                "The contrast() method requires a formula-based design. "
+                "When using a precomputed design matrix (DataFrame), "
+                "pass the contrast vector directly instead."
+            ) from None
 
     def fit_size_factors(
         self,


### PR DESCRIPTION
Fixes #440.

When `DeseqDataSet` is created with a precomputed design matrix (DataFrame) instead of a formula string, `cond()` and `contrast()` raise a confusing `AttributeError: 'DeseqDataSet' object has no attribute 'formulaic_contrasts'`.

Added try/except guards with clear error messages directing users to pass contrast vectors directly. Follows the same pattern already used for the `variables` property (line 341-347).